### PR TITLE
Add full EdgeXR NorthBound APIs

### DIFF
--- a/code/API_definitions/edgexr-nb-openapi.yaml
+++ b/code/API_definitions/edgexr-nb-openapi.yaml
@@ -1,0 +1,13433 @@
+# Auto-generated doc: DO NOT EDIT
+openapi: 3.0.3
+info:
+  description: The Master Controller (MC) serves as the central API gateway for users
+    to orchestrate edge resources and provides several APIs to both application developers
+    and operators. Application developers can manage and monitor deployment of edge
+    applications. Operators can manage and monitor the usage of cloudlet infrastructures.
+    Both developers and operators can manage users within their Organization.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  title: Edge Cloud Master Controller API Documentation
+  version: "2.0"
+servers:
+- description: localhost server
+  url: http://localhost:9900
+tags:
+- description: Authentication is done by a user name or email plus a password. The
+    login function returns a JSON Web Token (JWT) once authenticated, that should
+    be included with subsequent API calls to authenticate the user. The JWT will expire
+    after a while for security, at which point you may need to log in again.
+  name: Security
+- description: Users can be assigned roles for Organizations, allowing them to view
+    or manage resources associated with the Organizations.
+  name: User
+- description: Roles can be assigned to users for Organizations, allowing the users
+    to view or manage resources associated with the Organizations.
+  name: Role
+- description: Organizations group a set of resources together, for example Apps,
+    App Instances, or Cloudlets. Users given a role in an Organization can operate
+    on those resources in the scope provided by their role.
+  name: Organization
+- description: OperatorCode maps a carrier code to an Operator organization name.
+  name: OperatorCode
+- description: Flavors define the compute, memory and storage capacity of computing
+    instances. To put it simply, a flavor is an available hardware configuration for
+    a server. It defines the size of a virtual server that can be launched.
+  name: Flavor
+- description: AutoProvPolicy defines the automated provisioning policy.
+  name: AutoProvPolicy
+- description: AutoProvPolicy belonging to an app.
+  name: AppAutoProvPolicy
+- description: AutoScalePolicy defines when and how ClusterInsts will have their nodes
+    scaled up or down.
+  name: AutoScalePolicy
+- description: PrivacyPolicy defines security restrictions for cluster instances nodes
+    scaled up or down.
+  name: PrivacyPolicy
+- description: AutoProvPolicyCloudlet belong to a cloudlet.
+  name: AutoProvPolicyCloudlet
+- description: Pool of VMs to be part of a Cloudlet.
+  name: VMPool
+- description: Members belong to a VMPool.
+  name: VMPoolMember
+- description: Cloudlet is a set of compute resources at a particular location, provided
+    by an Operator.
+  name: Cloudlet
+- description: CloudletPool defines a pool of Cloudlets that have restricted access.
+  name: CloudletPool
+- description: Member belong to a cloudlet pool.
+  name: CloudletPoolMember
+- description: ClusterInst is an instance of a Cluster on a Cloudlet. It is defined
+    by a Cluster, Cloudlet, and Developer key.
+  name: ClusterInst
+- description: Provides information about the developer's application.
+  name: App
+- description: AppInst is an instance of an App on a Cloudlet where it is defined
+    by an App plus a ClusterInst key.
+  name: AppInst
+- description: Infra properties used to setup cloudlet.
+  name: CloudletProps
+- description: Cloudlet resouce mapping.
+  name: CloudletResMap
+- description: To match a flavor with platform flavor.
+  name: FlavorMatch
+- description: Client is an AppInst client that called FindCloudlet DME Api.
+  name: AppInstClientKey
+- description: ExecRequest is a common struct for enabling a connection to execute
+    some work on a container.
+  name: ExecRequest
+- description: Collection of statistics related to Client/App/Cluster.
+  name: DeveloperMetrics
+- description: Collection of statistics related to Cloudlet.
+  name: OperatorMetrics
+- description: Collection of event/audit logs from edge services.
+  name: Events
+- description: Usage details of App/Cluster.
+  name: DeveloperUsage
+- description: Usage details of Cloudlet.
+  name: OperatorUsage
+- description: Manage receiver for alerts from edge services.
+  name: AlertReceiver
+- description: Manage additional networks which can be added to Cluster Instances.
+  name: Network
+paths:
+  /api/v1/auth/alertreceiver/create:
+    post:
+      description: Create an alert receiver
+      operationId: CreateAlertReceiver
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiAlertReceiver'
+            x-required-fields:
+            - name
+            - type
+            - severity
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateAlertReceiver
+      tags:
+      - AlertReceiver
+  /api/v1/auth/alertreceiver/delete:
+    post:
+      description: Delete an alert receiver
+      operationId: DeleteAlertReceiver
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiAlertReceiver'
+            x-required-fields:
+            - name
+            - type
+            - severity
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteAlertReceiver
+      tags:
+      - AlertReceiver
+  /api/v1/auth/alertreceiver/show:
+    post:
+      description: Show alert receivers
+      operationId: ShowAlertReceiver
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiAlertReceiver'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiAlertReceiver'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAlertReceiver
+      tags:
+      - AlertReceiver
+  /api/v1/auth/artifactory/resync:
+    post:
+      description: Resync MC and Artifactory data
+      operationId: ArtifactoryResync
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ArtifactoryResync
+      tags:
+      - Repos
+  /api/v1/auth/billingorg/addchild:
+    post:
+      description: Add an organization as a child of a billing organization
+      operationId: AddBillingOrgChild
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiBillingOrganization'
+            x-required-fields:
+            - name
+            - children
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddBillingOrgChild
+      tags:
+      - BillingOrg
+  /api/v1/auth/billingorg/create:
+    post:
+      description: Set up a BillingOrganization and validate inputs
+      operationId: CreateBillingOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiBillingOrganization'
+            x-required-fields:
+            - name
+            - type
+            - firstname
+            - lastname
+            - email
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateBillingOrg
+      tags:
+      - BillingOrg
+  /api/v1/auth/billingorg/delete:
+    post:
+      description: Delete a billing organization
+      operationId: DeleteBillingOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiBillingOrganization'
+            x-required-fields:
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteBillingOrg
+      tags:
+      - BillingOrg
+  /api/v1/auth/billingorg/deletepaymentprofile:
+    post:
+      description: Remove a payment profile
+      operationId: DeletePaymentProfile
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiPaymentProfileDeletion'
+            x-required-fields:
+            - org
+            - id
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeletePaymentProfile
+      tags:
+      - BillingOrg
+  /api/v1/auth/billingorg/invoice:
+    post:
+      description: ""
+      operationId: GetInvoice
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiInvoiceRequest'
+            x-required-fields:
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/BillingInvoiceData'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GetInvoice
+      tags:
+      - BillingOrg
+  /api/v1/auth/billingorg/removechild:
+    post:
+      description: Remove an organization from a billing organization
+      operationId: RemoveBillingOrgChild
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiBillingOrganization'
+            x-required-fields:
+            - name
+            - children
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveBillingOrgChild
+      tags:
+      - BillingOrg
+  /api/v1/auth/billingorg/show:
+    post:
+      description: Show billing organizations
+      operationId: ShowBillingOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiBillingOrganization'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiBillingOrganization'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowBillingOrg
+      tags:
+      - BillingOrg
+  /api/v1/auth/billingorg/showaccount:
+    post:
+      description: Show billing account information
+      operationId: ShowAccountInfo
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiAccountInfo'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAccountInfo
+      tags:
+      - BillingOrg
+  /api/v1/auth/billingorg/showpaymentprofiles:
+    post:
+      description: Show payment profiles associated with the billing org
+      operationId: ShowPaymentProfiles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiBillingOrganization'
+            x-required-fields:
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/BillingPaymentProfile'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowPaymentProfiles
+      tags:
+      - BillingOrg
+  /api/v1/auth/billingorg/update:
+    post:
+      description: Update a billing organization
+      operationId: UpdateBillingOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiBillingOrganization'
+            x-required-fields:
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateBillingOrg
+      tags:
+      - BillingOrg
+  /api/v1/auth/cloudletpoolaccessgranted/show:
+    post:
+      description: Show granted cloudletpool access
+      operationId: ShowCloudletPoolAccessGranted
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletPoolAccessGranted
+      tags:
+      - CloudletPoolAccess
+  /api/v1/auth/cloudletpoolaccessinvitation/create:
+    post:
+      description: Create a cloudletpool invitation
+      operationId: CreateCloudletPoolAccessInvitation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+            x-required-fields:
+            - org
+            - region
+            - cloudletpool
+            - cloudletpoolorg
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateCloudletPoolAccessInvitation
+      tags:
+      - CloudletPoolInvitation
+  /api/v1/auth/cloudletpoolaccessinvitation/delete:
+    post:
+      description: Delete a cloudletpool invitation
+      operationId: DeleteCloudletPoolAccessInvitation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+            x-required-fields:
+            - org
+            - region
+            - cloudletpool
+            - cloudletpoolorg
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteCloudletPoolAccessInvitation
+      tags:
+      - CloudletPoolInvitation
+  /api/v1/auth/cloudletpoolaccessinvitation/show:
+    post:
+      description: Show cloudletpool invitations
+      operationId: ShowCloudletPoolAccessInvitation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletPoolAccessInvitation
+      tags:
+      - CloudletPoolInvitation
+  /api/v1/auth/cloudletpoolaccesspending/show:
+    post:
+      description: Show pending cloudletpool invitations without responses
+      operationId: ShowCloudletPoolAccessPending
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletPoolAccessPending
+      tags:
+      - CloudletPoolAccess
+  /api/v1/auth/cloudletpoolaccessresponse/create:
+    post:
+      description: Create a cloudletpool response to an invitation
+      operationId: CreateCloudletPoolAccessResponse
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+            x-required-fields:
+            - org
+            - region
+            - cloudletpool
+            - cloudletpoolorg
+            - decision
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateCloudletPoolAccessResponse
+      tags:
+      - CloudletPoolResponse
+  /api/v1/auth/cloudletpoolaccessresponse/delete:
+    post:
+      description: Delete a cloudletpool response to an invitation
+      operationId: DeleteCloudletPoolAccessResponse
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+            x-required-fields:
+            - org
+            - region
+            - cloudletpool
+            - cloudletpoolorg
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteCloudletPoolAccessResponse
+      tags:
+      - CloudletPoolResponse
+  /api/v1/auth/cloudletpoolaccessresponse/show:
+    post:
+      description: Show cloudletpool responses
+      operationId: ShowCloudletPoolAccessResponse
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiOrgCloudletPool'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletPoolAccessResponse
+      tags:
+      - CloudletPoolResponse
+  /api/v1/auth/config/reset:
+    post:
+      description: Reset master controller global configuration
+      operationId: ResetConfig
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ResetConfig
+      tags:
+      - Config
+  /api/v1/auth/config/show:
+    post:
+      description: Show master controller global configuration
+      operationId: ShowConfig
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiConfig'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowConfig
+      tags:
+      - Config
+  /api/v1/auth/config/update:
+    post:
+      description: Update master controller global configuration
+      operationId: UpdateConfig
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiConfig'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateConfig
+      tags:
+      - Config
+  /api/v1/auth/config/version:
+    post:
+      description: Show master controller version
+      operationId: MCVersion
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiVersion'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: MCVersion
+      tags:
+      - Config
+  /api/v1/auth/controller/create:
+    post:
+      description: Create a new regional controller
+      operationId: CreateController
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiController'
+            x-required-fields:
+            - region
+            - address
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateController
+      tags:
+      - Controller
+  /api/v1/auth/controller/delete:
+    post:
+      description: Delete a regional controller
+      operationId: DeleteController
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiController'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteController
+      tags:
+      - Controller
+  /api/v1/auth/controller/show:
+    post:
+      description: Show regional controllers
+      operationId: ShowController
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiController'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiController'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowController
+      tags:
+      - Controller
+  /api/v1/auth/controller/update:
+    post:
+      description: Update region controller
+      operationId: UpdateController
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiController'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateController
+      tags:
+      - Controller
+  /api/v1/auth/ctrl/AccessCloudlet:
+    post:
+      description: Access Cloudlet VM
+      operationId: AccessCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionExecRequest'
+            x-required-fields:
+            - region
+            - execrequest.appinstkey.clusterinstkey.cloudletkey.organization
+            - execrequest.appinstkey.clusterinstkey.cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoExecRequest'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AccessCloudlet
+      tags:
+      - Exec
+  /api/v1/auth/ctrl/AddAppAlertPolicy:
+    post:
+      description: Add an AlertPolicy to the application definition
+      operationId: AddAppAlertPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppAlertPolicy'
+            x-required-fields:
+            - region
+            - appalertpolicy.appkey.organization
+            - appalertpolicy.appkey.name
+            - appalertpolicy.appkey.version
+            - appalertpolicy.alertpolicy
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddAppAlertPolicy
+      tags:
+      - App
+  /api/v1/auth/ctrl/AddAppAutoProvPolicy:
+    post:
+      description: Add an AutoProvPolicy to the application definition
+      operationId: AddAppAutoProvPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppAutoProvPolicy'
+            x-required-fields:
+            - region
+            - appautoprovpolicy.appkey.organization
+            - appautoprovpolicy.appkey.name
+            - appautoprovpolicy.appkey.version
+            - appautoprovpolicy.autoprovpolicy
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddAppAutoProvPolicy
+      tags:
+      - App
+  /api/v1/auth/ctrl/AddAutoProvPolicyCloudlet:
+    post:
+      description: Add a Cloudlet to the Auto Provisioning Policy
+      operationId: AddAutoProvPolicyCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAutoProvPolicyCloudlet'
+            x-required-fields:
+            - region
+            - autoprovpolicycloudlet.key.organization
+            - autoprovpolicycloudlet.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddAutoProvPolicyCloudlet
+      tags:
+      - AutoProvPolicy
+  /api/v1/auth/ctrl/AddCloudletAllianceOrg:
+    post:
+      description: Add alliance organization to the cloudlet
+      operationId: AddCloudletAllianceOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletAllianceOrg'
+            x-required-fields:
+            - region
+            - cloudletallianceorg.key.organization
+            - cloudletallianceorg.key.name
+            - cloudletallianceorg.organization
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddCloudletAllianceOrg
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/AddCloudletPoolMember:
+    post:
+      description: Add a Cloudlet to a CloudletPool
+      operationId: AddCloudletPoolMember
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletPoolMember'
+            x-required-fields:
+            - region
+            - cloudletpoolmember.key.organization
+            - cloudletpoolmember.key.name
+            - cloudletpoolmember.cloudlet.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddCloudletPoolMember
+      tags:
+      - CloudletPool
+  /api/v1/auth/ctrl/AddCloudletResMapping:
+    post:
+      description: Add Optional Resource tag table
+      operationId: AddCloudletResMapping
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletResMap'
+            x-required-fields:
+            - region
+            - cloudletresmap.key.organization
+            - cloudletresmap.key.name
+            - cloudletresmap.mapping
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddCloudletResMapping
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/AddFlavorRes:
+    post:
+      description: Add Optional Resource
+      operationId: AddFlavorRes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlavor'
+            x-required-fields:
+            - region
+            - flavor.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddFlavorRes
+      tags:
+      - Flavor
+  /api/v1/auth/ctrl/AddGPUDriverBuild:
+    post:
+      description: Add GPU Driver Build. Adds new build to GPU driver.
+      operationId: AddGPUDriverBuild
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionGPUDriverBuildMember'
+            x-required-fields:
+            - region
+            - gpudriverbuildmember.key.name
+            - gpudriverbuildmember.key.organization
+            - gpudriverbuildmember.build.name
+            - gpudriverbuildmember.build.driverpath
+            - gpudriverbuildmember.build.operatingsystem
+            - gpudriverbuildmember.build.md5sum
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddGPUDriverBuild
+      tags:
+      - GPUDriver
+  /api/v1/auth/ctrl/AddResTag:
+    post:
+      description: Add new tag(s) to TagTable
+      operationId: AddResTag
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionResTagTable'
+            x-required-fields:
+            - region
+            - restagtable.key.name
+            - restagtable.key.organization
+            - restagtable.tags
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddResTag
+      tags:
+      - ResTagTable
+  /api/v1/auth/ctrl/AddVMPoolMember:
+    post:
+      description: Add VMPoolMember. Adds a VM to existing VM Pool.
+      operationId: AddVMPoolMember
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionVMPoolMember'
+            x-required-fields:
+            - region
+            - vmpoolmember.key.organization
+            - vmpoolmember.key.name
+            - vmpoolmember.vm.name
+            - vmpoolmember.vm.netinfo.internalip
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddVMPoolMember
+      tags:
+      - VMPool
+  /api/v1/auth/ctrl/CreateAlertPolicy:
+    post:
+      description: Create an Alert Policy
+      operationId: CreateAlertPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAlertPolicy'
+            x-required-fields:
+            - region
+            - alertpolicy.key.organization
+            - alertpolicy.key.name
+            - alertpolicy.severity
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateAlertPolicy
+      tags:
+      - AlertPolicy
+  /api/v1/auth/ctrl/CreateApp:
+    post:
+      description: Create Application. Creates a definition for an application for
+        Cloudlet deployment.
+      operationId: CreateApp
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionApp'
+            x-required-fields:
+            - region
+            - app.key.organization
+            - app.key.name
+            - app.key.version
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateApp
+      tags:
+      - App
+  /api/v1/auth/ctrl/CreateAppInst:
+    post:
+      description: Create Application Instance. Creates an instance of an App on a
+        Cloudlet where it is defined by an App plus a ClusterInst key. Many of the
+        fields here are inherited from the App definition.
+      operationId: CreateAppInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInst'
+            x-required-fields:
+            - region
+            - appinst.key.appkey.organization
+            - appinst.key.appkey.name
+            - appinst.key.appkey.version
+            - appinst.key.clusterinstkey.cloudletkey.organization
+            - appinst.key.clusterinstkey.cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateAppInst
+      tags:
+      - AppInst
+  /api/v1/auth/ctrl/CreateAutoProvPolicy:
+    post:
+      description: Create an Auto Provisioning Policy
+      operationId: CreateAutoProvPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAutoProvPolicy'
+            x-required-fields:
+            - region
+            - autoprovpolicy.key.organization
+            - autoprovpolicy.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateAutoProvPolicy
+      tags:
+      - AutoProvPolicy
+  /api/v1/auth/ctrl/CreateAutoScalePolicy:
+    post:
+      description: Create an Auto Scale Policy
+      operationId: CreateAutoScalePolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAutoScalePolicy'
+            x-required-fields:
+            - region
+            - autoscalepolicy.key.organization
+            - autoscalepolicy.key.name
+            - autoscalepolicy.minnodes
+            - autoscalepolicy.maxnodes
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateAutoScalePolicy
+      tags:
+      - AutoScalePolicy
+  /api/v1/auth/ctrl/CreateCloudlet:
+    post:
+      description: Create Cloudlet. Sets up Cloudlet services on the Operators compute
+        resources, and integrated as part of EdgeCloud edge resource portfolio. These
+        resources are managed from the Edge Controller.
+      operationId: CreateCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudlet'
+            x-required-fields:
+            - region
+            - cloudlet.key.organization
+            - cloudlet.key.name
+            - cloudlet.location.latitude
+            - cloudlet.location.longitude
+            - cloudlet.numdynamicips
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateCloudlet
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/CreateCloudletPool:
+    post:
+      description: Create a CloudletPool
+      operationId: CreateCloudletPool
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletPool'
+            x-required-fields:
+            - region
+            - cloudletpool.key.organization
+            - cloudletpool.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateCloudletPool
+      tags:
+      - CloudletPool
+  /api/v1/auth/ctrl/CreateClusterInst:
+    post:
+      description: Create Cluster Instance. Creates an instance of a Cluster on a
+        Cloudlet, defined by a Cluster Key and a Cloudlet Key. ClusterInst is a collection
+        of compute resources on a Cloudlet on which AppInsts are deployed.
+      operationId: CreateClusterInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClusterInst'
+            x-required-fields:
+            - region
+            - clusterinst.key.clusterkey.name
+            - clusterinst.key.cloudletkey.organization
+            - clusterinst.key.cloudletkey.name
+            - clusterinst.key.organization
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateClusterInst
+      tags:
+      - ClusterInst
+  /api/v1/auth/ctrl/CreateFlavor:
+    post:
+      description: Create a Flavor
+      operationId: CreateFlavor
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlavor'
+            x-required-fields:
+            - region
+            - flavor.key.name
+            - flavor.ram
+            - flavor.vcpus
+            - flavor.disk
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateFlavor
+      tags:
+      - Flavor
+  /api/v1/auth/ctrl/CreateFlowRateLimitSettings:
+    post:
+      description: Create Flow RateLimit settings for an API endpoint and target
+      operationId: CreateFlowRateLimitSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlowRateLimitSettings'
+            x-required-fields:
+            - region
+            - flowratelimitsettings.key.flowsettingsname
+            - flowratelimitsettings.key.ratelimitkey.apiname
+            - flowratelimitsettings.key.ratelimitkey.apiendpointtype
+            - flowratelimitsettings.key.ratelimitkey.ratelimittarget
+            - flowratelimitsettings.settings.flowalgorithm
+            - flowratelimitsettings.settings.reqspersecond
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateFlowRateLimitSettings
+      tags:
+      - RateLimitSettings
+  /api/v1/auth/ctrl/CreateGPUDriver:
+    post:
+      description: Create GPU Driver. Creates GPU driver with all the config required
+        to install it.
+      operationId: CreateGPUDriver
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionGPUDriver'
+            x-required-fields:
+            - region
+            - gpudriver.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateGPUDriver
+      tags:
+      - GPUDriver
+  /api/v1/auth/ctrl/CreateMaxReqsRateLimitSettings:
+    post:
+      description: Create MaxReqs RateLimit settings for an API endpoint and target
+      operationId: CreateMaxReqsRateLimitSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionMaxReqsRateLimitSettings'
+            x-required-fields:
+            - region
+            - maxreqsratelimitsettings.key.maxreqssettingsname
+            - maxreqsratelimitsettings.key.ratelimitkey.apiname
+            - maxreqsratelimitsettings.key.ratelimitkey.apiendpointtype
+            - maxreqsratelimitsettings.key.ratelimitkey.ratelimittarget
+            - maxreqsratelimitsettings.settings.maxreqsalgorithm
+            - maxreqsratelimitsettings.settings.maxrequests
+            - maxreqsratelimitsettings.settings.interval
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateMaxReqsRateLimitSettings
+      tags:
+      - RateLimitSettings
+  /api/v1/auth/ctrl/CreateNetwork:
+    post:
+      description: Create a Network
+      operationId: CreateNetwork
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionNetwork'
+            x-required-fields:
+            - region
+            - network.key.cloudletkey.organization
+            - network.key.cloudletkey.name
+            - network.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateNetwork
+      tags:
+      - Network
+  /api/v1/auth/ctrl/CreateOperatorCode:
+    post:
+      description: Create Operator Code. Create a code for an Operator.
+      operationId: CreateOperatorCode
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionOperatorCode'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateOperatorCode
+      tags:
+      - OperatorCode
+  /api/v1/auth/ctrl/CreateResTagTable:
+    post:
+      description: Create TagTable
+      operationId: CreateResTagTable
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionResTagTable'
+            x-required-fields:
+            - region
+            - restagtable.key.name
+            - restagtable.key.organization
+            - restagtable.tags
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateResTagTable
+      tags:
+      - ResTagTable
+  /api/v1/auth/ctrl/CreateTrustPolicy:
+    post:
+      description: Create a Trust Policy
+      operationId: CreateTrustPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionTrustPolicy'
+            x-required-fields:
+            - region
+            - trustpolicy.key.organization
+            - trustpolicy.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateTrustPolicy
+      tags:
+      - TrustPolicy
+  /api/v1/auth/ctrl/CreateTrustPolicyException:
+    post:
+      description: Create a Trust Policy Exception, by App Developer Organization
+      operationId: CreateTrustPolicyException
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionTrustPolicyException'
+            x-required-fields:
+            - region
+            - trustpolicyexception.key.appkey.organization
+            - trustpolicyexception.key.appkey.name
+            - trustpolicyexception.key.appkey.version
+            - trustpolicyexception.key.cloudletpoolkey.organization
+            - trustpolicyexception.key.cloudletpoolkey.name
+            - trustpolicyexception.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateTrustPolicyException
+      tags:
+      - TrustPolicyException
+  /api/v1/auth/ctrl/CreateVMPool:
+    post:
+      description: Create VMPool. Creates VM pool which will have VMs defined.
+      operationId: CreateVMPool
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionVMPool'
+            x-required-fields:
+            - region
+            - vmpool.key.organization
+            - vmpool.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateVMPool
+      tags:
+      - VMPool
+  /api/v1/auth/ctrl/DeleteAlertPolicy:
+    post:
+      description: Delete an Alert Policy
+      operationId: DeleteAlertPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAlertPolicy'
+            x-required-fields:
+            - region
+            - alertpolicy.key.organization
+            - alertpolicy.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteAlertPolicy
+      tags:
+      - AlertPolicy
+  /api/v1/auth/ctrl/DeleteApp:
+    post:
+      description: Delete Application. Deletes a definition of an application. Instances
+        of the application must be deleted first.
+      operationId: DeleteApp
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionApp'
+            x-required-fields:
+            - region
+            - app.key.organization
+            - app.key.name
+            - app.key.version
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteApp
+      tags:
+      - App
+  /api/v1/auth/ctrl/DeleteAppInst:
+    post:
+      description: Delete Application Instance. Deletes an instance of the App from
+        the Cloudlet.
+      operationId: DeleteAppInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInst'
+            x-required-fields:
+            - region
+            - appinst.key.appkey.organization
+            - appinst.key.appkey.name
+            - appinst.key.appkey.version
+            - appinst.key.clusterinstkey.cloudletkey.organization
+            - appinst.key.clusterinstkey.cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteAppInst
+      tags:
+      - AppInst
+  /api/v1/auth/ctrl/DeleteAutoProvPolicy:
+    post:
+      description: Delete an Auto Provisioning Policy
+      operationId: DeleteAutoProvPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAutoProvPolicy'
+            x-required-fields:
+            - region
+            - autoprovpolicy.key.organization
+            - autoprovpolicy.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteAutoProvPolicy
+      tags:
+      - AutoProvPolicy
+  /api/v1/auth/ctrl/DeleteAutoScalePolicy:
+    post:
+      description: Delete an Auto Scale Policy
+      operationId: DeleteAutoScalePolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAutoScalePolicy'
+            x-required-fields:
+            - region
+            - autoscalepolicy.key.organization
+            - autoscalepolicy.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteAutoScalePolicy
+      tags:
+      - AutoScalePolicy
+  /api/v1/auth/ctrl/DeleteCloudlet:
+    post:
+      description: Delete Cloudlet. Removes the Cloudlet services where they are no
+        longer managed from the Edge Controller.
+      operationId: DeleteCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudlet'
+            x-required-fields:
+            - region
+            - cloudlet.key.organization
+            - cloudlet.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteCloudlet
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/DeleteCloudletPool:
+    post:
+      description: Delete a CloudletPool
+      operationId: DeleteCloudletPool
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletPool'
+            x-required-fields:
+            - region
+            - cloudletpool.key.organization
+            - cloudletpool.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteCloudletPool
+      tags:
+      - CloudletPool
+  /api/v1/auth/ctrl/DeleteClusterInst:
+    post:
+      description: Delete Cluster Instance. Deletes an instance of a Cluster deployed
+        on a Cloudlet.
+      operationId: DeleteClusterInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClusterInst'
+            x-required-fields:
+            - region
+            - clusterinst.key.clusterkey.name
+            - clusterinst.key.cloudletkey.organization
+            - clusterinst.key.cloudletkey.name
+            - clusterinst.key.organization
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteClusterInst
+      tags:
+      - ClusterInst
+  /api/v1/auth/ctrl/DeleteFlavor:
+    post:
+      description: Delete a Flavor
+      operationId: DeleteFlavor
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlavor'
+            x-required-fields:
+            - region
+            - flavor.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteFlavor
+      tags:
+      - Flavor
+  /api/v1/auth/ctrl/DeleteFlowRateLimitSettings:
+    post:
+      description: Delete Flow RateLimit settings for an API endpoint and target
+      operationId: DeleteFlowRateLimitSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlowRateLimitSettings'
+            x-required-fields:
+            - region
+            - flowratelimitsettings.key.flowsettingsname
+            - flowratelimitsettings.key.ratelimitkey.apiname
+            - flowratelimitsettings.key.ratelimitkey.apiendpointtype
+            - flowratelimitsettings.key.ratelimitkey.ratelimittarget
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteFlowRateLimitSettings
+      tags:
+      - RateLimitSettings
+  /api/v1/auth/ctrl/DeleteGPUDriver:
+    post:
+      description: Delete GPU Driver. Deletes GPU driver given that it is not used
+        by any cloudlet.
+      operationId: DeleteGPUDriver
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionGPUDriver'
+            x-required-fields:
+            - region
+            - gpudriver.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteGPUDriver
+      tags:
+      - GPUDriver
+  /api/v1/auth/ctrl/DeleteIdleReservableClusterInsts:
+    post:
+      description: Cleanup Reservable Cluster Instances. Deletes reservable cluster
+        instances that are not in use.
+      operationId: DeleteIdleReservableClusterInsts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionIdleReservableClusterInsts'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteIdleReservableClusterInsts
+      tags:
+      - ClusterInst
+  /api/v1/auth/ctrl/DeleteMaxReqsRateLimitSettings:
+    post:
+      description: Delete MaxReqs RateLimit settings for an API endpoint and target
+      operationId: DeleteMaxReqsRateLimitSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionMaxReqsRateLimitSettings'
+            x-required-fields:
+            - region
+            - maxreqsratelimitsettings.key.maxreqssettingsname
+            - maxreqsratelimitsettings.key.ratelimitkey.apiname
+            - maxreqsratelimitsettings.key.ratelimitkey.apiendpointtype
+            - maxreqsratelimitsettings.key.ratelimitkey.ratelimittarget
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteMaxReqsRateLimitSettings
+      tags:
+      - RateLimitSettings
+  /api/v1/auth/ctrl/DeleteNetwork:
+    post:
+      description: Delete a Network
+      operationId: DeleteNetwork
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionNetwork'
+            x-required-fields:
+            - region
+            - network.key.cloudletkey.organization
+            - network.key.cloudletkey.name
+            - network.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteNetwork
+      tags:
+      - Network
+  /api/v1/auth/ctrl/DeleteOperatorCode:
+    post:
+      description: Delete Operator Code. Delete a code for an Operator.
+      operationId: DeleteOperatorCode
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionOperatorCode'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteOperatorCode
+      tags:
+      - OperatorCode
+  /api/v1/auth/ctrl/DeleteResTagTable:
+    post:
+      description: Delete TagTable
+      operationId: DeleteResTagTable
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionResTagTable'
+            x-required-fields:
+            - region
+            - restagtable.key.name
+            - restagtable.key.organization
+            - restagtable.tags
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteResTagTable
+      tags:
+      - ResTagTable
+  /api/v1/auth/ctrl/DeleteTrustPolicy:
+    post:
+      description: Delete a Trust policy
+      operationId: DeleteTrustPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionTrustPolicy'
+            x-required-fields:
+            - region
+            - trustpolicy.key.organization
+            - trustpolicy.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteTrustPolicy
+      tags:
+      - TrustPolicy
+  /api/v1/auth/ctrl/DeleteTrustPolicyException:
+    post:
+      description: Delete a Trust Policy Exception, by App Developer Organization
+      operationId: DeleteTrustPolicyException
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionTrustPolicyException'
+            x-required-fields:
+            - region
+            - trustpolicyexception.key.appkey.organization
+            - trustpolicyexception.key.appkey.name
+            - trustpolicyexception.key.appkey.version
+            - trustpolicyexception.key.cloudletpoolkey.organization
+            - trustpolicyexception.key.cloudletpoolkey.name
+            - trustpolicyexception.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteTrustPolicyException
+      tags:
+      - TrustPolicyException
+  /api/v1/auth/ctrl/DeleteVMPool:
+    post:
+      description: Delete VMPool. Deletes VM pool given that none of VMs part of this
+        pool is used.
+      operationId: DeleteVMPool
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionVMPool'
+            x-required-fields:
+            - region
+            - vmpool.key.organization
+            - vmpool.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteVMPool
+      tags:
+      - VMPool
+  /api/v1/auth/ctrl/DisableDebugLevels:
+    post:
+      description: Disable debug log levels
+      operationId: DisableDebugLevels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionDebugRequest'
+            x-required-fields:
+            - debugrequest.levels
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoDebugReply'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DisableDebugLevels
+      tags:
+      - Debug
+  /api/v1/auth/ctrl/EnableDebugLevels:
+    post:
+      description: Enable debug log levels
+      operationId: EnableDebugLevels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionDebugRequest'
+            x-required-fields:
+            - debugrequest.levels
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoDebugReply'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: EnableDebugLevels
+      tags:
+      - Debug
+  /api/v1/auth/ctrl/EvictCloudletInfo:
+    post:
+      description: Evict (delete) a CloudletInfo for regression testing
+      operationId: EvictCloudletInfo
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletInfo'
+            x-required-fields:
+            - region
+            - cloudletinfo.key.organization
+            - cloudletinfo.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: EvictCloudletInfo
+      tags:
+      - CloudletInfo
+  /api/v1/auth/ctrl/EvictDevice:
+    post:
+      description: Evict a device
+      operationId: EvictDevice
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionDevice'
+            x-required-fields:
+            - region
+            - device.key.uniqueidtype
+            - device.key.uniqueid
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: EvictDevice
+      tags:
+      - Device
+  /api/v1/auth/ctrl/FindFlavorMatch:
+    post:
+      description: Discover if flavor produces a matching platform flavor
+      operationId: FindFlavorMatch
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlavorMatch'
+            x-required-fields:
+            - region
+            - flavormatch.key.organization
+            - flavormatch.key.name
+            - flavormatch.flavorname
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoFlavorMatch'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: FindFlavorMatch
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/GenerateAccessKey:
+    post:
+      description: Generate new crm access key
+      operationId: GenerateAccessKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletKey'
+            x-required-fields:
+            - region
+            - cloudletkey.organization
+            - cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GenerateAccessKey
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/GetCloudletGPUDriverLicenseConfig:
+    post:
+      description: Get Cloudlet Specific GPU Driver License Config. Returns the license
+        config associated with the cloudlet
+      operationId: GetCloudletGPUDriverLicenseConfig
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletKey'
+            x-required-fields:
+            - region
+            - cloudletkey.organization
+            - cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GetCloudletGPUDriverLicenseConfig
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/GetCloudletManifest:
+    post:
+      description: Get Cloudlet Manifest. Shows deployment manifest required to setup
+        cloudlet
+      operationId: GetCloudletManifest
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletKey'
+            x-required-fields:
+            - region
+            - cloudletkey.organization
+            - cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoCloudletManifest'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GetCloudletManifest
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/GetCloudletProps:
+    post:
+      description: Get Cloudlet Properties. Shows all the infra properties used to
+        setup cloudlet
+      operationId: GetCloudletProps
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletProps'
+            x-required-fields:
+            - region
+            - cloudletprops.platformtype
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoCloudletProps'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GetCloudletProps
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/GetCloudletResourceQuotaProps:
+    post:
+      description: Get Cloudlet Resource Quota Properties. Shows all the resource
+        quota properties of the cloudlet
+      operationId: GetCloudletResourceQuotaProps
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletResourceQuotaProps'
+            x-required-fields:
+            - region
+            - cloudletresourcequotaprops.platformtype
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoCloudletResourceQuotaProps'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GetCloudletResourceQuotaProps
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/GetCloudletResourceUsage:
+    post:
+      description: Get Cloudlet resource information. Shows cloudlet resources used
+        and their limits
+      operationId: GetCloudletResourceUsage
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletResourceUsage'
+            x-required-fields:
+            - region
+            - cloudletresourceusage.key.organization
+            - cloudletresourceusage.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoCloudletResourceUsage'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GetCloudletResourceUsage
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/GetGPUDriverBuildURL:
+    post:
+      description: Get GPU Driver Build URL. Returns a time-limited signed URL to
+        download GPU driver.
+      operationId: GetGPUDriverBuildURL
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionGPUDriverBuildMember'
+            x-required-fields:
+            - region
+            - gpudriverbuildmember.key.name
+            - gpudriverbuildmember.key.organization
+            - gpudriverbuildmember.build.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoGPUDriverBuildURL'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GetGPUDriverBuildURL
+      tags:
+      - GPUDriver
+  /api/v1/auth/ctrl/GetGPUDriverLicenseConfig:
+    post:
+      description: Get GPU Driver License Config. Returns the license config specific
+        to GPU driver
+      operationId: GetGPUDriverLicenseConfig
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionGPUDriverKey'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GetGPUDriverLicenseConfig
+      tags:
+      - GPUDriver
+  /api/v1/auth/ctrl/GetOrganizationsOnCloudlet:
+    post:
+      description: Get organizations of ClusterInsts and AppInsts on cloudlet
+      operationId: GetOrganizationsOnCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletKey'
+            x-required-fields:
+            - region
+            - cloudletkey.organization
+            - cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoOrganization'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GetOrganizationsOnCloudlet
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/GetResTagTable:
+    post:
+      description: Fetch a copy of the TagTable
+      operationId: GetResTagTable
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionResTagTableKey'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResTagTable'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GetResTagTable
+      tags:
+      - ResTagTable
+  /api/v1/auth/ctrl/InjectCloudletInfo:
+    post:
+      description: Inject (create) a CloudletInfo for regression testing
+      operationId: InjectCloudletInfo
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletInfo'
+            x-required-fields:
+            - region
+            - cloudletinfo.key.organization
+            - cloudletinfo.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: InjectCloudletInfo
+      tags:
+      - CloudletInfo
+  /api/v1/auth/ctrl/InjectDevice:
+    post:
+      description: Inject a device
+      operationId: InjectDevice
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionDevice'
+            x-required-fields:
+            - region
+            - device.key.uniqueidtype
+            - device.key.uniqueid
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: InjectDevice
+      tags:
+      - Device
+  /api/v1/auth/ctrl/RefreshAppInst:
+    post:
+      description: Refresh Application Instance. Restarts an App instance with new
+        App settings or image.
+      operationId: RefreshAppInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInst'
+            x-required-fields:
+            - region
+            - appinst.key.appkey.organization
+            - appinst.key.appkey.name
+            - appinst.key.appkey.version
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RefreshAppInst
+      tags:
+      - AppInst
+  /api/v1/auth/ctrl/RemoveAppAlertPolicy:
+    post:
+      description: Remove an AlertPolicy from the application definition
+      operationId: RemoveAppAlertPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppAlertPolicy'
+            x-required-fields:
+            - region
+            - appalertpolicy.appkey.organization
+            - appalertpolicy.appkey.name
+            - appalertpolicy.appkey.version
+            - appalertpolicy.alertpolicy
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveAppAlertPolicy
+      tags:
+      - App
+  /api/v1/auth/ctrl/RemoveAppAutoProvPolicy:
+    post:
+      description: Remove an AutoProvPolicy from the application definition
+      operationId: RemoveAppAutoProvPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppAutoProvPolicy'
+            x-required-fields:
+            - region
+            - appautoprovpolicy.appkey.organization
+            - appautoprovpolicy.appkey.name
+            - appautoprovpolicy.appkey.version
+            - appautoprovpolicy.autoprovpolicy
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveAppAutoProvPolicy
+      tags:
+      - App
+  /api/v1/auth/ctrl/RemoveAutoProvPolicyCloudlet:
+    post:
+      description: Remove a Cloudlet from the Auto Provisioning Policy
+      operationId: RemoveAutoProvPolicyCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAutoProvPolicyCloudlet'
+            x-required-fields:
+            - region
+            - autoprovpolicycloudlet.key.organization
+            - autoprovpolicycloudlet.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveAutoProvPolicyCloudlet
+      tags:
+      - AutoProvPolicy
+  /api/v1/auth/ctrl/RemoveCloudletAllianceOrg:
+    post:
+      description: Remove alliance organization from the cloudlet
+      operationId: RemoveCloudletAllianceOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletAllianceOrg'
+            x-required-fields:
+            - region
+            - cloudletallianceorg.key.organization
+            - cloudletallianceorg.key.name
+            - cloudletallianceorg.organization
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveCloudletAllianceOrg
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/RemoveCloudletPoolMember:
+    post:
+      description: Remove a Cloudlet from a CloudletPool
+      operationId: RemoveCloudletPoolMember
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletPoolMember'
+            x-required-fields:
+            - region
+            - cloudletpoolmember.key.organization
+            - cloudletpoolmember.key.name
+            - cloudletpoolmember.cloudlet.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveCloudletPoolMember
+      tags:
+      - CloudletPool
+  /api/v1/auth/ctrl/RemoveCloudletResMapping:
+    post:
+      description: Remove Optional Resource tag table
+      operationId: RemoveCloudletResMapping
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletResMap'
+            x-required-fields:
+            - region
+            - cloudletresmap.key.organization
+            - cloudletresmap.key.name
+            - cloudletresmap.mapping
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveCloudletResMapping
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/RemoveFlavorRes:
+    post:
+      description: Remove Optional Resource
+      operationId: RemoveFlavorRes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlavor'
+            x-required-fields:
+            - region
+            - flavor.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveFlavorRes
+      tags:
+      - Flavor
+  /api/v1/auth/ctrl/RemoveGPUDriverBuild:
+    post:
+      description: Remove GPU Driver Build. Removes build from GPU driver.
+      operationId: RemoveGPUDriverBuild
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionGPUDriverBuildMember'
+            x-required-fields:
+            - region
+            - gpudriverbuildmember.key.name
+            - gpudriverbuildmember.key.organization
+            - gpudriverbuildmember.build.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveGPUDriverBuild
+      tags:
+      - GPUDriver
+  /api/v1/auth/ctrl/RemoveResTag:
+    post:
+      description: Remove existing tag(s) from TagTable
+      operationId: RemoveResTag
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionResTagTable'
+            x-required-fields:
+            - region
+            - restagtable.key.name
+            - restagtable.key.organization
+            - restagtable.tags
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveResTag
+      tags:
+      - ResTagTable
+  /api/v1/auth/ctrl/RemoveVMPoolMember:
+    post:
+      description: Remove VMPoolMember. Removes a VM from existing VM Pool.
+      operationId: RemoveVMPoolMember
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionVMPoolMember'
+            x-required-fields:
+            - region
+            - vmpoolmember.key.organization
+            - vmpoolmember.key.name
+            - vmpoolmember.vm.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveVMPoolMember
+      tags:
+      - VMPool
+  /api/v1/auth/ctrl/RequestAppInstLatency:
+    post:
+      description: Request Latency measurements for clients connected to AppInst
+      operationId: RequestAppInstLatency
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInstLatency'
+            x-required-fields:
+            - region
+            - appinstlatency.key.appkey.organization
+            - appinstlatency.key.appkey.name
+            - appinstlatency.key.appkey.version
+            - appinstlatency.key.clusterinstkey.cloudletkey.organization
+            - appinstlatency.key.clusterinstkey.cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RequestAppInstLatency
+      tags:
+      - AppInstLatency
+  /api/v1/auth/ctrl/ResetSettings:
+    post:
+      description: Reset all settings to their defaults
+      operationId: ResetSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionSettings'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ResetSettings
+      tags:
+      - Settings
+  /api/v1/auth/ctrl/RevokeAccessKey:
+    post:
+      description: Revoke crm access key
+      operationId: RevokeAccessKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletKey'
+            x-required-fields:
+            - region
+            - cloudletkey.organization
+            - cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RevokeAccessKey
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/RunCommand:
+    post:
+      description: Run a Command or Shell on a container
+      operationId: RunCommand
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionExecRequest'
+            x-required-fields:
+            - region
+            - execrequest.appinstkey.appkey.organization
+            - execrequest.appinstkey.appkey.name
+            - execrequest.appinstkey.appkey.version
+            - execrequest.appinstkey.clusterinstkey.clusterkey.name
+            - execrequest.appinstkey.clusterinstkey.cloudletkey.organization
+            - execrequest.appinstkey.clusterinstkey.cloudletkey.name
+            - execrequest.cmd.command
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoExecRequest'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RunCommand
+      tags:
+      - Exec
+  /api/v1/auth/ctrl/RunConsole:
+    post:
+      description: Run console on a VM
+      operationId: RunConsole
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionExecRequest'
+            x-required-fields:
+            - region
+            - execrequest.appinstkey.appkey.organization
+            - execrequest.appinstkey.appkey.name
+            - execrequest.appinstkey.appkey.version
+            - execrequest.appinstkey.clusterinstkey.cloudletkey.organization
+            - execrequest.appinstkey.clusterinstkey.cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoExecRequest'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RunConsole
+      tags:
+      - Exec
+  /api/v1/auth/ctrl/RunDebug:
+    post:
+      description: Run debug command
+      operationId: RunDebug
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionDebugRequest'
+            x-required-fields:
+            - debugrequest.cmd
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoDebugReply'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RunDebug
+      tags:
+      - Debug
+  /api/v1/auth/ctrl/ShowAlert:
+    post:
+      description: Show alerts
+      operationId: ShowAlert
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAlert'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoAlert'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAlert
+      tags:
+      - Alert
+  /api/v1/auth/ctrl/ShowAlertPolicy:
+    post:
+      description: Show Alert Policies. Any fields specified will be used to filter
+        results.
+      operationId: ShowAlertPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAlertPolicy'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoAlertPolicy'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAlertPolicy
+      tags:
+      - AlertPolicy
+  /api/v1/auth/ctrl/ShowApp:
+    post:
+      description: Show Applications. Lists all application definitions. Any fields
+        specified will be used to filter results.
+      operationId: ShowApp
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionApp'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoApp'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowApp
+      tags:
+      - App
+  /api/v1/auth/ctrl/ShowAppInst:
+    post:
+      description: Show Application Instances. Lists all the Application instances
+        managed by the Edge Controller. Any fields specified will be used to filter
+        results.
+      operationId: ShowAppInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInst'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoAppInst'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAppInst
+      tags:
+      - AppInst
+  /api/v1/auth/ctrl/ShowAppInstClient:
+    post:
+      description: Show application instance clients.
+      operationId: ShowAppInstClient
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInstClientKey'
+            x-required-fields:
+            - region
+            - appinstclientkey.appinstkey.appkey.organization
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoAppInstClient'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAppInstClient
+      tags:
+      - AppInstClient
+  /api/v1/auth/ctrl/ShowAppInstRefs:
+    post:
+      description: Show AppInstRefs (debug only)
+      operationId: ShowAppInstRefs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInstRefs'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoAppInstRefs'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAppInstRefs
+      tags:
+      - AppInstRefs
+  /api/v1/auth/ctrl/ShowAutoProvPolicy:
+    post:
+      description: Show Auto Provisioning Policies. Any fields specified will be used
+        to filter results.
+      operationId: ShowAutoProvPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAutoProvPolicy'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoAutoProvPolicy'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAutoProvPolicy
+      tags:
+      - AutoProvPolicy
+  /api/v1/auth/ctrl/ShowAutoScalePolicy:
+    post:
+      description: Show Auto Scale Policies. Any fields specified will be used to
+        filter results.
+      operationId: ShowAutoScalePolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAutoScalePolicy'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoAutoScalePolicy'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAutoScalePolicy
+      tags:
+      - AutoScalePolicy
+  /api/v1/auth/ctrl/ShowCloudlet:
+    post:
+      description: Show Cloudlets. Lists all the cloudlets managed from Edge Controller.
+      operationId: ShowCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudlet'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoCloudlet'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudlet
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/ShowCloudletInfo:
+    post:
+      description: Show CloudletInfos
+      operationId: ShowCloudletInfo
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletInfo'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoCloudletInfo'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletInfo
+      tags:
+      - CloudletInfo
+  /api/v1/auth/ctrl/ShowCloudletPool:
+    post:
+      description: Show CloudletPools
+      operationId: ShowCloudletPool
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletPool'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoCloudletPool'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletPool
+      tags:
+      - CloudletPool
+  /api/v1/auth/ctrl/ShowCloudletRefs:
+    post:
+      description: Show CloudletRefs (debug only)
+      operationId: ShowCloudletRefs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletRefs'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoCloudletRefs'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletRefs
+      tags:
+      - CloudletRefs
+  /api/v1/auth/ctrl/ShowCloudletsForAppDeployment:
+    post:
+      description: Discover cloudlets supporting deployments of App.DefaultFlavor
+      operationId: ShowCloudletsForAppDeployment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionDeploymentCloudletRequest'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoCloudletKey'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletsForAppDeployment
+      tags:
+      - App
+  /api/v1/auth/ctrl/ShowClusterInst:
+    post:
+      description: Show Cluster Instances. Lists all the cluster instances managed
+        by Edge Controller.
+      operationId: ShowClusterInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClusterInst'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoClusterInst'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowClusterInst
+      tags:
+      - ClusterInst
+  /api/v1/auth/ctrl/ShowClusterRefs:
+    post:
+      description: Show ClusterRefs (debug only)
+      operationId: ShowClusterRefs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClusterRefs'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoClusterRefs'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowClusterRefs
+      tags:
+      - ClusterRefs
+  /api/v1/auth/ctrl/ShowDebugLevels:
+    post:
+      description: Show debug log levels
+      operationId: ShowDebugLevels
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionDebugRequest'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoDebugReply'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowDebugLevels
+      tags:
+      - Debug
+  /api/v1/auth/ctrl/ShowDevice:
+    post:
+      description: Show devices
+      operationId: ShowDevice
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionDevice'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoDevice'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowDevice
+      tags:
+      - Device
+  /api/v1/auth/ctrl/ShowDeviceReport:
+    post:
+      description: Device Reports API.
+      operationId: ShowDeviceReport
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionDeviceReport'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoDevice'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowDeviceReport
+      tags:
+      - Device
+  /api/v1/auth/ctrl/ShowFlavor:
+    post:
+      description: Show Flavors
+      operationId: ShowFlavor
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlavor'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoFlavor'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowFlavor
+      tags:
+      - Flavor
+  /api/v1/auth/ctrl/ShowFlavorsForCloudlet:
+    post:
+      description: Find all meta flavors viable on cloudlet
+      operationId: ShowFlavorsForCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletKey'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoFlavorKey'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowFlavorsForCloudlet
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/ShowFlowRateLimitSettings:
+    post:
+      description: Show Flow RateLimit settings for an API endpoint and target
+      operationId: ShowFlowRateLimitSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlowRateLimitSettings'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoFlowRateLimitSettings'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowFlowRateLimitSettings
+      tags:
+      - RateLimitSettings
+  /api/v1/auth/ctrl/ShowGPUDriver:
+    post:
+      description: Show GPU Drivers. Lists all the EdgeCloud created GPU drivers and
+        operator created GPU drivers.
+      operationId: ShowGPUDriver
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionGPUDriver'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoGPUDriver'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowGPUDriver
+      tags:
+      - GPUDriver
+  /api/v1/auth/ctrl/ShowLogs:
+    post:
+      description: View logs for AppInst
+      operationId: ShowLogs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionExecRequest'
+            x-required-fields:
+            - region
+            - execrequest.appinstkey.appkey.organization
+            - execrequest.appinstkey.appkey.name
+            - execrequest.appinstkey.appkey.version
+            - execrequest.appinstkey.clusterinstkey.clusterkey.name
+            - execrequest.appinstkey.clusterinstkey.cloudletkey.organization
+            - execrequest.appinstkey.clusterinstkey.cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoExecRequest'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowLogs
+      tags:
+      - Exec
+  /api/v1/auth/ctrl/ShowMaxReqsRateLimitSettings:
+    post:
+      description: Show MaxReqs RateLimit settings for an API endpoint and target
+      operationId: ShowMaxReqsRateLimitSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionMaxReqsRateLimitSettings'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoMaxReqsRateLimitSettings'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowMaxReqsRateLimitSettings
+      tags:
+      - RateLimitSettings
+  /api/v1/auth/ctrl/ShowNetwork:
+    post:
+      description: Show Networks. Any fields specified will be used to filter results.
+      operationId: ShowNetwork
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionNetwork'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoNetwork'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowNetwork
+      tags:
+      - Network
+  /api/v1/auth/ctrl/ShowNode:
+    post:
+      description: Show all Nodes connected to all Controllers
+      operationId: ShowNode
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionNode'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoNode'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowNode
+      tags:
+      - Node
+  /api/v1/auth/ctrl/ShowOperatorCode:
+    post:
+      description: Show Operator Code. Show Codes for an Operator.
+      operationId: ShowOperatorCode
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionOperatorCode'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoOperatorCode'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowOperatorCode
+      tags:
+      - OperatorCode
+  /api/v1/auth/ctrl/ShowRateLimitSettings:
+    post:
+      description: Show RateLimit settings for an API endpoint and target
+      operationId: ShowRateLimitSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionRateLimitSettings'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoRateLimitSettings'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowRateLimitSettings
+      tags:
+      - RateLimitSettings
+  /api/v1/auth/ctrl/ShowResTagTable:
+    post:
+      description: Show TagTable
+      operationId: ShowResTagTable
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionResTagTable'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResTagTable'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowResTagTable
+      tags:
+      - ResTagTable
+  /api/v1/auth/ctrl/ShowSettings:
+    post:
+      description: Show settings
+      operationId: ShowSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionSettings'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoSettings'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowSettings
+      tags:
+      - Settings
+  /api/v1/auth/ctrl/ShowTrustPolicy:
+    post:
+      description: Show Trust Policies. Any fields specified will be used to filter
+        results.
+      operationId: ShowTrustPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionTrustPolicy'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoTrustPolicy'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowTrustPolicy
+      tags:
+      - TrustPolicy
+  /api/v1/auth/ctrl/ShowTrustPolicyException:
+    post:
+      description: Show Trust Policy Exceptions. Any fields specified will be used
+        to filter results.
+      operationId: ShowTrustPolicyException
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionTrustPolicyException'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoTrustPolicyException'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowTrustPolicyException
+      tags:
+      - TrustPolicyException
+  /api/v1/auth/ctrl/ShowVMPool:
+    post:
+      description: Show VMPools. Lists all the VMs part of the VM pool.
+      operationId: ShowVMPool
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionVMPool'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoVMPool'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowVMPool
+      tags:
+      - VMPool
+  /api/v1/auth/ctrl/StreamAppInst:
+    post:
+      description: Stream Application Instance current progress
+      operationId: StreamAppInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInstKey'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: StreamAppInst
+      tags:
+      - StreamObj
+  /api/v1/auth/ctrl/StreamCloudlet:
+    post:
+      description: Stream Cloudlet current progress
+      operationId: StreamCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletKey'
+            x-required-fields:
+            - region
+            - cloudletkey.organization
+            - cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: StreamCloudlet
+      tags:
+      - StreamObj
+  /api/v1/auth/ctrl/StreamClusterInst:
+    post:
+      description: Stream Cluster Instance current progress
+      operationId: StreamClusterInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClusterInstKey'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: StreamClusterInst
+      tags:
+      - StreamObj
+  /api/v1/auth/ctrl/StreamGPUDriver:
+    post:
+      description: Stream GPU driver current progress
+      operationId: StreamGPUDriver
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionGPUDriverKey'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: StreamGPUDriver
+      tags:
+      - StreamObj
+  /api/v1/auth/ctrl/UpdateAlertPolicy:
+    post:
+      description: Update an Alert Policy
+      operationId: UpdateAlertPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAlertPolicy'
+            x-required-fields:
+            - region
+            - alertpolicy.key.organization
+            - alertpolicy.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateAlertPolicy
+      tags:
+      - AlertPolicy
+  /api/v1/auth/ctrl/UpdateApp:
+    post:
+      description: Update Application. Updates the definition of an application.
+      operationId: UpdateApp
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionApp'
+            x-required-fields:
+            - region
+            - app.key.organization
+            - app.key.name
+            - app.key.version
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateApp
+      tags:
+      - App
+  /api/v1/auth/ctrl/UpdateAppInst:
+    post:
+      description: Update Application Instance. Updates an Application instance and
+        then refreshes it.
+      operationId: UpdateAppInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInst'
+            x-required-fields:
+            - region
+            - appinst.key.appkey.organization
+            - appinst.key.appkey.name
+            - appinst.key.appkey.version
+            - appinst.key.clusterinstkey.cloudletkey.organization
+            - appinst.key.clusterinstkey.cloudletkey.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateAppInst
+      tags:
+      - AppInst
+  /api/v1/auth/ctrl/UpdateAutoProvPolicy:
+    post:
+      description: Update an Auto Provisioning Policy
+      operationId: UpdateAutoProvPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAutoProvPolicy'
+            x-required-fields:
+            - region
+            - autoprovpolicy.key.organization
+            - autoprovpolicy.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateAutoProvPolicy
+      tags:
+      - AutoProvPolicy
+  /api/v1/auth/ctrl/UpdateAutoScalePolicy:
+    post:
+      description: Update an Auto Scale Policy
+      operationId: UpdateAutoScalePolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAutoScalePolicy'
+            x-required-fields:
+            - region
+            - autoscalepolicy.key.organization
+            - autoscalepolicy.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateAutoScalePolicy
+      tags:
+      - AutoScalePolicy
+  /api/v1/auth/ctrl/UpdateCloudlet:
+    post:
+      description: Update Cloudlet. Updates the Cloudlet configuration and manages
+        the upgrade of Cloudlet services.
+      operationId: UpdateCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudlet'
+            x-required-fields:
+            - region
+            - cloudlet.key.organization
+            - cloudlet.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateCloudlet
+      tags:
+      - Cloudlet
+  /api/v1/auth/ctrl/UpdateCloudletPool:
+    post:
+      description: Update a CloudletPool
+      operationId: UpdateCloudletPool
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletPool'
+            x-required-fields:
+            - region
+            - cloudletpool.key.organization
+            - cloudletpool.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateCloudletPool
+      tags:
+      - CloudletPool
+  /api/v1/auth/ctrl/UpdateClusterInst:
+    post:
+      description: Update Cluster Instance. Updates an instance of a Cluster deployed
+        on a Cloudlet.
+      operationId: UpdateClusterInst
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClusterInst'
+            x-required-fields:
+            - region
+            - clusterinst.key.clusterkey.name
+            - clusterinst.key.cloudletkey.organization
+            - clusterinst.key.cloudletkey.name
+            - clusterinst.key.organization
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateClusterInst
+      tags:
+      - ClusterInst
+  /api/v1/auth/ctrl/UpdateFlavor:
+    post:
+      description: Update a Flavor
+      operationId: UpdateFlavor
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlavor'
+            x-required-fields:
+            - region
+            - flavor.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateFlavor
+      tags:
+      - Flavor
+  /api/v1/auth/ctrl/UpdateFlowRateLimitSettings:
+    post:
+      description: Update Flow RateLimit settings for an API endpoint and target
+      operationId: UpdateFlowRateLimitSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionFlowRateLimitSettings'
+            x-required-fields:
+            - region
+            - flowratelimitsettings.key.flowsettingsname
+            - flowratelimitsettings.key.ratelimitkey.apiname
+            - flowratelimitsettings.key.ratelimitkey.apiendpointtype
+            - flowratelimitsettings.key.ratelimitkey.ratelimittarget
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateFlowRateLimitSettings
+      tags:
+      - RateLimitSettings
+  /api/v1/auth/ctrl/UpdateGPUDriver:
+    post:
+      description: Update GPU Driver. Updates GPU driver config.
+      operationId: UpdateGPUDriver
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionGPUDriver'
+            x-required-fields:
+            - region
+            - gpudriver.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateGPUDriver
+      tags:
+      - GPUDriver
+  /api/v1/auth/ctrl/UpdateMaxReqsRateLimitSettings:
+    post:
+      description: Update MaxReqs RateLimit settings for an API endpoint and target
+      operationId: UpdateMaxReqsRateLimitSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionMaxReqsRateLimitSettings'
+            x-required-fields:
+            - region
+            - maxreqsratelimitsettings.key.maxreqssettingsname
+            - maxreqsratelimitsettings.key.ratelimitkey.apiname
+            - maxreqsratelimitsettings.key.ratelimitkey.apiendpointtype
+            - maxreqsratelimitsettings.key.ratelimitkey.ratelimittarget
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateMaxReqsRateLimitSettings
+      tags:
+      - RateLimitSettings
+  /api/v1/auth/ctrl/UpdateNetwork:
+    post:
+      description: Update a Network
+      operationId: UpdateNetwork
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionNetwork'
+            x-required-fields:
+            - region
+            - network.key.cloudletkey.organization
+            - network.key.cloudletkey.name
+            - network.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateNetwork
+      tags:
+      - Network
+  /api/v1/auth/ctrl/UpdateResTagTable:
+    post:
+      description: Update TagTable
+      operationId: UpdateResTagTable
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionResTagTable'
+            x-required-fields:
+            - region
+            - restagtable.key.name
+            - restagtable.key.organization
+            - restagtable.tags
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateResTagTable
+      tags:
+      - ResTagTable
+  /api/v1/auth/ctrl/UpdateSettings:
+    post:
+      description: Update settings
+      operationId: UpdateSettings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionSettings'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateSettings
+      tags:
+      - Settings
+  /api/v1/auth/ctrl/UpdateTrustPolicy:
+    post:
+      description: Update a Trust policy
+      operationId: UpdateTrustPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionTrustPolicy'
+            x-required-fields:
+            - region
+            - trustpolicy.key.organization
+            - trustpolicy.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateTrustPolicy
+      tags:
+      - TrustPolicy
+  /api/v1/auth/ctrl/UpdateTrustPolicyException:
+    post:
+      description: Update a Trust Policy Exception, by Operator Organization
+      operationId: UpdateTrustPolicyException
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionTrustPolicyException'
+            x-required-fields:
+            - region
+            - trustpolicyexception.key.appkey.organization
+            - trustpolicyexception.key.appkey.name
+            - trustpolicyexception.key.appkey.version
+            - trustpolicyexception.key.cloudletpoolkey.organization
+            - trustpolicyexception.key.cloudletpoolkey.name
+            - trustpolicyexception.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateTrustPolicyException
+      tags:
+      - TrustPolicyException
+  /api/v1/auth/ctrl/UpdateVMPool:
+    post:
+      description: Update VMPool. Updates a VM pools VMs.
+      operationId: UpdateVMPool
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionVMPool'
+            x-required-fields:
+            - region
+            - vmpool.key.organization
+            - vmpool.key.name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeprotoResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateVMPool
+      tags:
+      - VMPool
+  /api/v1/auth/events/app:
+    post:
+      description: View App billing events
+      operationId: ShowAppEvents
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInstEvents'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAppEvents
+      tags:
+      - BillingEvents
+  /api/v1/auth/events/cloudlet:
+    post:
+      description: View Cloudlet billing events
+      operationId: ShowCloudletEvents
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletEvents'
+            x-required-fields:
+            - region
+            - cloudlet.organization
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletEvents
+      tags:
+      - BillingEvents
+  /api/v1/auth/events/cluster:
+    post:
+      description: View ClusterInst billing events
+      operationId: ShowClusterEvents
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClusterInstEvents'
+            x-required-fields:
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowClusterEvents
+      tags:
+      - BillingEvents
+  /api/v1/auth/events/find:
+    post:
+      description: Find events and audit events, results sorted by relevance
+      operationId: FindEvents
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeEventSearch'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/NodeEventData'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: FindEvents
+      tags:
+      - Events
+  /api/v1/auth/events/show:
+    post:
+      description: Show events and audit events
+      operationId: ShowEvents
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeEventSearch'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/NodeEventData'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowEvents
+      tags:
+      - Events
+  /api/v1/auth/events/terms:
+    post:
+      description: Show aggregated events terms
+      operationId: EventTerms
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeEventSearch'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeEventTerms'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: EventTerms
+      tags:
+      - Events
+  /api/v1/auth/federation/create:
+    post:
+      description: Create Federation
+      operationId: CreateFederation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederation'
+            x-required-fields:
+            - selfoperatorid
+            - selffederationid
+            - name
+            - federator.operatorid
+            - federator.countrycode
+            - federator.federationid
+            - federator.federationaddr
+            - federator.apikey
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateFederation
+      tags:
+      - Federation
+  /api/v1/auth/federation/delete:
+    post:
+      description: Delete Federation
+      operationId: DeleteFederation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederation'
+            x-required-fields:
+            - selfoperatorid
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteFederation
+      tags:
+      - Federation
+  /api/v1/auth/federation/deregister:
+    post:
+      description: Deregister Federation
+      operationId: DeregisterFederation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederation'
+            x-required-fields:
+            - selfoperatorid
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeregisterFederation
+      tags:
+      - Federation
+  /api/v1/auth/federation/partner/setapikey:
+    post:
+      description: Set Partner Federation API Key
+      operationId: SetPartnerFederationAPIKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederation'
+            x-required-fields:
+            - selfoperatorid
+            - name
+            - federator.apikey
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: SetPartnerFederationAPIKey
+      tags:
+      - Federation
+  /api/v1/auth/federation/partner/zone/show:
+    post:
+      description: Show Federated Partner Zones
+      operationId: ShowFederatedPartnerZone
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederatedPartnerZone'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiFederatedPartnerZone'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowFederatedPartnerZone
+      tags:
+      - FederatorZone
+  /api/v1/auth/federation/register:
+    post:
+      description: Register Federation
+      operationId: RegisterFederation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederation'
+            x-required-fields:
+            - selfoperatorid
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RegisterFederation
+      tags:
+      - Federation
+  /api/v1/auth/federation/self/zone/show:
+    post:
+      description: Show Federated Self Zones
+      operationId: ShowFederatedSelfZone
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederatedSelfZone'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiFederatedSelfZone'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowFederatedSelfZone
+      tags:
+      - FederatorZone
+  /api/v1/auth/federation/show:
+    post:
+      description: Show Federation
+      operationId: ShowFederation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederation'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiFederation'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowFederation
+      tags:
+      - Federation
+  /api/v1/auth/federator/partner/zone/deregister:
+    post:
+      description: DeRegister Partner Federator Zone
+      operationId: DeRegisterPartnerFederatorZone
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederatedZoneRegRequest'
+            x-required-fields:
+            - selfoperatorid
+            - federationname
+            - zones
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeRegisterPartnerFederatorZone
+      tags:
+      - FederatorZone
+  /api/v1/auth/federator/partner/zone/register:
+    post:
+      description: Register Partner Federator Zone
+      operationId: RegisterPartnerFederatorZone
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederatedZoneRegRequest'
+            x-required-fields:
+            - selfoperatorid
+            - federationname
+            - zones
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RegisterPartnerFederatorZone
+      tags:
+      - FederatorZone
+  /api/v1/auth/federator/self/create:
+    post:
+      description: Create Self Federator
+      operationId: CreateSelfFederator
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederator'
+            x-required-fields:
+            - operatorid
+            - countrycode
+            - region
+            - mcc
+            - mnc
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiFederator'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateSelfFederator
+      tags:
+      - Federator
+  /api/v1/auth/federator/self/delete:
+    post:
+      description: Delete Self Federator
+      operationId: DeleteSelfFederator
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederator'
+            x-required-fields:
+            - operatorid
+            - federationid
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteSelfFederator
+      tags:
+      - Federator
+  /api/v1/auth/federator/self/generateapikey:
+    post:
+      description: Generate Self Federator API Key
+      operationId: GenerateSelfFederatorAPIKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederator'
+            x-required-fields:
+            - operatorid
+            - federationid
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiFederator'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GenerateSelfFederatorAPIKey
+      tags:
+      - Federator
+  /api/v1/auth/federator/self/show:
+    post:
+      description: Show Self Federator
+      operationId: ShowSelfFederator
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederator'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiFederator'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowSelfFederator
+      tags:
+      - Federator
+  /api/v1/auth/federator/self/update:
+    post:
+      description: Update Self Federator
+      operationId: UpdateSelfFederator
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederator'
+            x-required-fields:
+            - operatorid
+            - federationid
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateSelfFederator
+      tags:
+      - Federator
+  /api/v1/auth/federator/self/zone/create:
+    post:
+      description: Create Self Federator Zone
+      operationId: CreateSelfFederatorZone
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederatorZone'
+            x-required-fields:
+            - zoneid
+            - operatorid
+            - countrycode
+            - cloudlets
+            - geolocation
+            - region
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateSelfFederatorZone
+      tags:
+      - FederatorZone
+  /api/v1/auth/federator/self/zone/delete:
+    post:
+      description: Delete Self Federator Zone
+      operationId: DeleteSelfFederatorZone
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederatorZone'
+            x-required-fields:
+            - zoneid
+            - operatorid
+            - countrycode
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteSelfFederatorZone
+      tags:
+      - FederatorZone
+  /api/v1/auth/federator/self/zone/share:
+    post:
+      description: Share Self Federator Zone
+      operationId: ShareSelfFederatorZone
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederatedSelfZone'
+            x-required-fields:
+            - zoneid
+            - selfoperatorid
+            - federationname
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShareSelfFederatorZone
+      tags:
+      - FederatorZone
+  /api/v1/auth/federator/self/zone/show:
+    post:
+      description: Show Self Federator Zone
+      operationId: ShowSelfFederatorZone
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederatorZone'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiFederatorZone'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowSelfFederatorZone
+      tags:
+      - FederatorZone
+  /api/v1/auth/federator/self/zone/unshare:
+    post:
+      description: Unshare Self Federator Zone
+      operationId: UnshareSelfFederatorZone
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiFederatedSelfZone'
+            x-required-fields:
+            - zoneid
+            - selfoperatorid
+            - federationname
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UnshareSelfFederatorZone
+      tags:
+      - FederatorZone
+  /api/v1/auth/gitlab/resync:
+    post:
+      description: Resync MC and Gitlab data
+      operationId: GitlabResync
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GitlabResync
+      tags:
+      - Repos
+  /api/v1/auth/metrics/app:
+    post:
+      description: View App metrics
+      operationId: ShowAppMetrics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInstMetrics'
+            x-required-fields:
+            - region
+            - selector
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAppMetrics
+      tags:
+      - Metrics
+  /api/v1/auth/metrics/app/v2:
+    post:
+      description: View App metrics(v2 format)
+      operationId: ShowAppV2Metrics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCustomAppMetrics'
+            x-required-fields:
+            - region
+            - measurement
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAppV2Metrics
+      tags:
+      - MetricsV2
+  /api/v1/auth/metrics/clientapiusage:
+    post:
+      description: View client API usage
+      operationId: ShowClientApiUsageMetrics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClientApiUsageMetrics'
+            x-required-fields:
+            - region
+            - selector
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowClientApiUsageMetrics
+      tags:
+      - Metrics
+  /api/v1/auth/metrics/clientappusage:
+    post:
+      description: View client App usage
+      operationId: ShowClientAppUsageMetrics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClientAppUsageMetrics'
+            x-required-fields:
+            - region
+            - selector
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowClientAppUsageMetrics
+      tags:
+      - Metrics
+  /api/v1/auth/metrics/clientcloudletusage:
+    post:
+      description: View client Cloudlet usage
+      operationId: ShowClientCloudletUsageMetrics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClientCloudletUsageMetrics'
+            x-required-fields:
+            - region
+            - cloudlet.organization
+            - selector
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowClientCloudletUsageMetrics
+      tags:
+      - Metrics
+  /api/v1/auth/metrics/cloudlet:
+    post:
+      description: View Cloudlet metrics
+      operationId: ShowCloudletMetrics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletMetrics'
+            x-required-fields:
+            - region
+            - selector
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletMetrics
+      tags:
+      - Metrics
+  /api/v1/auth/metrics/cloudlet/usage:
+    post:
+      description: View Cloudlet usage
+      operationId: ShowCloudletUsage
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletMetrics'
+            x-required-fields:
+            - region
+            - selector
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletUsage
+      tags:
+      - Metrics
+  /api/v1/auth/metrics/cluster:
+    post:
+      description: View ClusterInst metrics
+      operationId: ShowClusterMetrics
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClusterInstMetrics'
+            x-required-fields:
+            - region
+            - selector
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowClusterMetrics
+      tags:
+      - Metrics
+  /api/v1/auth/org/create:
+    post:
+      description: Create a new developer or operator organization
+      operationId: CreateOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrganization'
+            x-required-fields:
+            - name
+            - type
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateOrg
+      tags:
+      - Org
+  /api/v1/auth/org/delete:
+    post:
+      description: Delete an organization
+      operationId: DeleteOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrganization'
+            x-required-fields:
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteOrg
+      tags:
+      - Org
+  /api/v1/auth/org/show:
+    post:
+      description: Show organizations
+      operationId: ShowOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrganization'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiOrganization'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowOrg
+      tags:
+      - Org
+  /api/v1/auth/org/update:
+    post:
+      description: Update an organization
+      operationId: UpdateOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrganization'
+            x-required-fields:
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateOrg
+      tags:
+      - Org
+  /api/v1/auth/orgcloudlet/show:
+    post:
+      description: ""
+      operationId: ShowOrgCloudlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrgCloudlet'
+            x-required-fields:
+            - region
+            - org
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/EdgeprotoCloudlet'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowOrgCloudlet
+      tags:
+      - OrgCloudlet
+  /api/v1/auth/orgcloudletinfo/show:
+    post:
+      description: ""
+      operationId: ShowOrgCloudletInfo
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrgCloudlet'
+            x-required-fields:
+            - region
+            - org
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/EdgeprotoCloudletInfo'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowOrgCloudletInfo
+      tags:
+      - OrgCloudletInfo
+  /api/v1/auth/ratelimitsettingsmc/createflow:
+    post:
+      description: Create master controller flowratelimitsettings
+      operationId: CreateFlowRateLimitSettingsMc
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiMcRateLimitFlowSettings'
+            x-required-fields:
+            - flowsettingsname
+            - apiname
+            - ratelimittarget
+            - flowalgorithm
+            - reqspersecond
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateFlowRateLimitSettingsMc
+      tags:
+      - RateLimitSettingsMc
+  /api/v1/auth/ratelimitsettingsmc/createmaxreqs:
+    post:
+      description: Create master controller maxreqsratelimitsettings
+      operationId: CreateMaxReqsRateLimitSettingsMc
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiMcRateLimitMaxReqsSettings'
+            x-required-fields:
+            - maxreqssettingsname
+            - apiname
+            - ratelimittarget
+            - maxreqsalgorithm
+            - maxrequests
+            - interval
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateMaxReqsRateLimitSettingsMc
+      tags:
+      - RateLimitSettingsMc
+  /api/v1/auth/ratelimitsettingsmc/deleteflow:
+    post:
+      description: Delete master controller flowratelimitsettings
+      operationId: DeleteFlowRateLimitSettingsMc
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiMcRateLimitFlowSettings'
+            x-required-fields:
+            - flowsettingsname
+            - apiname
+            - ratelimittarget
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteFlowRateLimitSettingsMc
+      tags:
+      - RateLimitSettingsMc
+  /api/v1/auth/ratelimitsettingsmc/deletemaxreqs:
+    post:
+      description: Delete master controller maxreqsratelimitsettings
+      operationId: DeleteMaxReqsRateLimitSettingsMc
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiMcRateLimitMaxReqsSettings'
+            x-required-fields:
+            - maxreqssettingsname
+            - apiname
+            - ratelimittarget
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteMaxReqsRateLimitSettingsMc
+      tags:
+      - RateLimitSettingsMc
+  /api/v1/auth/ratelimitsettingsmc/show:
+    post:
+      description: Show master controller ratelimitsettings
+      operationId: ShowRateLimitSettingsMc
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiMcRateLimitSettings'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiMcRateLimitSettings'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowRateLimitSettingsMc
+      tags:
+      - RateLimitSettingsMc
+  /api/v1/auth/ratelimitsettingsmc/showflow:
+    post:
+      description: Show master controller flowratelimitsettings
+      operationId: ShowFlowRateLimitSettingsMc
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiMcRateLimitFlowSettings'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiMcRateLimitFlowSettings'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowFlowRateLimitSettingsMc
+      tags:
+      - RateLimitSettingsMc
+  /api/v1/auth/ratelimitsettingsmc/showmaxreqs:
+    post:
+      description: Show master controller maxreqsratelimitsettings
+      operationId: ShowMaxReqsRateLimitSettingsMc
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiMcRateLimitMaxReqsSettings'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiMcRateLimitMaxReqsSettings'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowMaxReqsRateLimitSettingsMc
+      tags:
+      - RateLimitSettingsMc
+  /api/v1/auth/ratelimitsettingsmc/updateflow:
+    post:
+      description: Update master controller flowratelimitsettings
+      operationId: UpdateFlowRateLimitSettingsMc
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiMcRateLimitFlowSettings'
+            x-required-fields:
+            - flowsettingsname
+            - apiname
+            - ratelimittarget
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateFlowRateLimitSettingsMc
+      tags:
+      - RateLimitSettingsMc
+  /api/v1/auth/ratelimitsettingsmc/updatemaxreqs:
+    post:
+      description: Update master controller maxreqsratelimitsettings
+      operationId: UpdateMaxReqsRateLimitSettingsMc
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiMcRateLimitMaxReqsSettings'
+            x-required-fields:
+            - maxreqssettingsname
+            - apiname
+            - ratelimittarget
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateMaxReqsRateLimitSettingsMc
+      tags:
+      - RateLimitSettingsMc
+  /api/v1/auth/report/download:
+    post:
+      description: Download generated report
+      operationId: DownloadReport
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiDownloadReport'
+            x-required-fields:
+            - org
+            - filename
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DownloadReport
+      tags:
+      - Report
+  /api/v1/auth/report/generate:
+    post:
+      description: Generate new report for an org of all regions
+      operationId: GenerateReport
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiGenerateReport'
+            x-required-fields:
+            - org
+            - starttime
+            - endtime
+      responses:
+        "200":
+          content:
+            text/html;charset=UTF-8:
+              schema:
+                format: binary
+                type: string
+          description: pdf document
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GenerateReport
+      tags:
+      - Report
+  /api/v1/auth/report/generatedata:
+    post:
+      description: Generate report data for an org of all regions
+      operationId: GenerateReportData
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiGenerateReport'
+            x-required-fields:
+            - org
+            - starttime
+            - endtime
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Generic mapped map[string]interface data
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: GenerateReportData
+      tags:
+      - ReportData
+  /api/v1/auth/report/show:
+    post:
+      description: Show already generated reports for an org
+      operationId: ShowReport
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiDownloadReport'
+            x-required-fields:
+            - org
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowReport
+      tags:
+      - Report
+  /api/v1/auth/reporter/create:
+    post:
+      description: Create new reporter
+      operationId: CreateReporter
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiReporter'
+            x-required-fields:
+            - name
+            - org
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateReporter
+      tags:
+      - Reporter
+  /api/v1/auth/reporter/delete:
+    post:
+      description: Delete reporter
+      operationId: DeleteReporter
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiReporter'
+            x-required-fields:
+            - name
+            - org
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteReporter
+      tags:
+      - Reporter
+  /api/v1/auth/reporter/show:
+    post:
+      description: Show reporters
+      operationId: ShowReporter
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiReporter'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiReporter'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowReporter
+      tags:
+      - Reporter
+  /api/v1/auth/reporter/update:
+    post:
+      description: Update reporter
+      operationId: UpdateReporter
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiReporter'
+            x-required-fields:
+            - name
+            - org
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateReporter
+      tags:
+      - Reporter
+  /api/v1/auth/restricted/org/update:
+    post:
+      description: Admin-only update of org fields, requires name
+      operationId: RestrictedUpdateOrg
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiOrganization'
+            x-required-fields:
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RestrictedUpdateOrg
+  /api/v1/auth/restricted/user/update:
+    post:
+      description: Admin-only update of various user fields, requires name or email
+      operationId: RestrictedUpdateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiUser'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RestrictedUpdateUser
+  /api/v1/auth/role/adduser:
+    post:
+      description: Add a role for the organization to the user
+      operationId: AddUserRole
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRole'
+            x-required-fields:
+            - org
+            - username
+            - role
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: AddUserRole
+      tags:
+      - Role
+  /api/v1/auth/role/assignment/show:
+    post:
+      description: Show roles for the current user
+      operationId: ShowRoleAssignment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRole'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiRole'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowRoleAssignment
+      tags:
+      - Role
+  /api/v1/auth/role/perms/show:
+    post:
+      description: Show permissions associated with each role
+      operationId: ShowRolePerm
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRolePerm'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiRolePerm'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowRolePerm
+      tags:
+      - Role
+  /api/v1/auth/role/removeuser:
+    post:
+      description: Remove the role for the organization from the user
+      operationId: RemoveUserRole
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRole'
+            x-required-fields:
+            - org
+            - username
+            - role
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: RemoveUserRole
+      tags:
+      - Role
+  /api/v1/auth/role/show:
+    post:
+      description: Show role names
+      operationId: ShowRoleNames
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowRoleNames
+      tags:
+      - Role
+  /api/v1/auth/role/showuser:
+    post:
+      description: Show roles for the organizations the current user can add or remove
+        roles to
+      operationId: ShowUserRole
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRole'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiRole'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowUserRole
+      tags:
+      - Role
+  /api/v1/auth/spans/show:
+    post:
+      description: Search spans
+      operationId: ShowSpans
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeSpanSearch'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/NodeSpanOutCondensed'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowSpans
+      tags:
+      - Spans
+  /api/v1/auth/spans/showverbose:
+    post:
+      description: Search spans, output raw format
+      operationId: ShowSpansVerbose
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeSpanSearch'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/DbmodelSpan'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowSpansVerbose
+      tags:
+      - Spans
+  /api/v1/auth/spans/terms:
+    post:
+      description: Show aggregated spans terms
+      operationId: SpanTerms
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeSpanSearch'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeSpanTerms'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: SpanTerms
+      tags:
+      - Spans
+  /api/v1/auth/usage/app:
+    post:
+      description: View App usage
+      operationId: ShowAppUsage
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionAppInstUsage'
+            x-required-fields:
+            - region
+            - starttime
+            - endtime
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowAppUsage
+      tags:
+      - Usage
+  /api/v1/auth/usage/cloudletpool:
+    post:
+      description: View CloudletPool usage
+      operationId: ShowCloudletPoolUsage
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionCloudletPoolUsage'
+            x-required-fields:
+            - region
+            - cloudletpool.name
+            - cloudletpool.organization
+            - starttime
+            - endtime
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowCloudletPoolUsage
+      tags:
+      - Usage
+  /api/v1/auth/usage/cluster:
+    post:
+      description: View ClusterInst usage
+      operationId: ShowClusterUsage
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiRegionClusterInstUsage'
+            x-required-fields:
+            - region
+            - starttime
+            - endtime
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiAllMetrics'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowClusterUsage
+      tags:
+      - Usage
+  /api/v1/auth/user/create/apikey:
+    post:
+      description: Create an API key for reduced access, typically for automation
+      operationId: CreateUserApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiCreateUserApiKey'
+            x-required-fields:
+            - userapikey.org
+            - userapikey.description
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiCreateUserApiKey'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CreateUserApiKey
+      tags:
+      - User
+  /api/v1/auth/user/current:
+    post:
+      description: Show the currently logged in user
+      operationId: CurrentUser
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiUser'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: CurrentUser
+      tags:
+      - User
+  /api/v1/auth/user/delete:
+    post:
+      description: Delete an existing user
+      operationId: DeleteUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiUser'
+            x-required-fields:
+            - name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteUser
+      tags:
+      - User
+  /api/v1/auth/user/delete/apikey:
+    post:
+      description: Delete an API key
+      operationId: DeleteUserApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiCreateUserApiKey'
+            x-required-fields:
+            - userapikey.id
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: DeleteUserApiKey
+      tags:
+      - User
+  /api/v1/auth/user/newpass:
+    post:
+      description: Set a new password while logged in, requires the existing password
+      operationId: NewPassword
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiNewPassword'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: NewPassword
+      tags:
+      - User
+  /api/v1/auth/user/show:
+    post:
+      description: Show users
+      operationId: ShowUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiShowUser'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiUser'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowUser
+      tags:
+      - User
+  /api/v1/auth/user/show/apikey:
+    post:
+      description: Show existing API keys
+      operationId: ShowUserApiKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiCreateUserApiKey'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/OrmapiCreateUserApiKey'
+                type: array
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: ShowUserApiKey
+      tags:
+      - User
+  /api/v1/auth/user/update:
+    post:
+      description: Update a user
+      operationId: UpdateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiCreateUser'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiUserResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+        "403":
+          description: Forbidden
+      security:
+      - bearerAuth: []
+      summary: UpdateUser
+      tags:
+      - User
+  /api/v1/login:
+    post:
+      description: Login using account credentials
+      operationId: Login
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiUserLogin'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Map with key "token" whose value is the JWT key to be used
+            in subsequent API calls, and "admin" to indicate if the user is an admin
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+      summary: Login
+  /api/v1/passwordreset:
+    post:
+      description: Reset the password using the token from the password reset email
+      operationId: PasswordReset
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiPasswordReset'
+            x-required-fields:
+            - token
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+      summary: PasswordReset
+      tags:
+      - User
+  /api/v1/passwordresetrequest:
+    post:
+      description: Request a password reset email to be sent to the user's email
+      operationId: PasswordResetRequest
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiEmailRequest'
+            x-required-fields:
+            - email
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+      summary: PasswordResetRequest
+      tags:
+      - User
+  /api/v1/publicconfig:
+    post:
+      description: Show publicly visible master controller global configuration
+      operationId: ShowPublicConfig
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiConfig'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+      summary: ShowPublicConfig
+      tags:
+      - Config
+  /api/v1/resendverify:
+    post:
+      description: Request that the user verification email be resent
+      operationId: ResendVerify
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiEmailRequest'
+            x-required-fields:
+            - email
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+      summary: ResendVerify
+      tags:
+      - User
+  /api/v1/usercreate:
+    post:
+      description: Create a new user
+      operationId: CreateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiCreateUser'
+            x-required-fields:
+            - user.name
+            - user.email
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiUserResponse'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+      summary: CreateUser
+      tags:
+      - User
+  /api/v1/verifyemail:
+    post:
+      description: Verify a user's email account from the token in the email
+      operationId: VerifyEmail
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrmapiToken'
+            x-required-fields:
+            - token
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrmapiResult'
+          description: Bad Request
+      summary: VerifyEmail
+      tags:
+      - User
+components:
+  schemas:
+    BillingAddress:
+      properties:
+        city:
+          type: string
+        country:
+          type: string
+        line2:
+          type: string
+        state:
+          type: string
+        street:
+          type: string
+        zip:
+          type: string
+      type: object
+    BillingCredits:
+      properties:
+        applied_amount:
+          type: string
+        credit_note_number:
+          type: string
+        credit_note_uid:
+          type: string
+        memo:
+          type: string
+        original_amount:
+          type: string
+        transaction_time:
+          type: string
+        uid:
+          type: string
+      type: object
+    BillingDiscounts:
+      properties:
+        code:
+          type: string
+        discount_amount:
+          type: string
+        discount_type:
+          type: string
+        eligible_amount:
+          type: string
+        line_items_breakouts:
+          items:
+            $ref: '#/components/schemas/BillingLineItemsBreakouts'
+          type: array
+        percentage:
+          type: string
+        source_id:
+          type: integer
+        source_type:
+          type: string
+        title:
+          type: string
+        uid:
+          type: string
+      type: object
+    BillingInvoiceData:
+      properties:
+        billing_address:
+          $ref: '#/components/schemas/BillingAddress'
+        collection_method:
+          type: string
+        consolidation_level:
+          type: string
+        credit_amount:
+          type: string
+        credits:
+          items:
+            $ref: '#/components/schemas/BillingCredits'
+          type: array
+        currency:
+          description: ISO 4217 currency code
+          type: string
+        customer:
+          properties:
+            email:
+              type: string
+            first_name:
+              type: string
+            last_name:
+              type: string
+            organization:
+              type: string
+          type: object
+        discount_amount:
+          type: string
+        discounts:
+          items:
+            $ref: '#/components/schemas/BillingDiscounts'
+          type: array
+        due_amount:
+          description: Amount due, which is total - credit - paid
+          type: string
+        due_date:
+          description: Date the invoice is due.
+          type: string
+        issue_date:
+          description: Date the invoice was issued to the customer
+          type: string
+        line_items:
+          items:
+            $ref: '#/components/schemas/BillingLineItems'
+          type: array
+        memo:
+          type: string
+        number:
+          description: A unique string that identifies the invoice
+          type: string
+        paid_amount:
+          description: Paid amount
+          type: string
+        paid_date:
+          description: Date the invoice was fully paid
+          type: string
+        payment_instructions:
+          type: string
+        payments:
+          items:
+            $ref: '#/components/schemas/BillingPayments'
+          type: array
+        previous_balance_data:
+          $ref: '#/components/schemas/BillingPrevBalanceData'
+        product_name:
+          type: string
+        refund_amount:
+          type: string
+        refunds:
+          items:
+            $ref: '#/components/schemas/BillingRefunds'
+          type: array
+        seller:
+          properties:
+            address:
+              $ref: '#/components/schemas/BillingAddress'
+            name:
+              type: string
+            phone:
+              type: string
+          type: object
+        shipping_address:
+          $ref: '#/components/schemas/BillingAddress'
+        status:
+          type: string
+        subtotal_amount:
+          description: Subtotal of invoice, sum of all line items before discounts
+            or taxes
+          type: string
+        tax_amount:
+          type: string
+        taxes:
+          items:
+            $ref: '#/components/schemas/BillingTaxes'
+          type: array
+        total_amount:
+          description: Total amount, which subtotal - discount + tax
+          type: string
+      type: object
+    BillingLineItems:
+      properties:
+        component_id:
+          type: integer
+        description:
+          type: string
+        discount_amount:
+          type: string
+        period_range_end:
+          type: string
+        period_range_start:
+          type: string
+        price_point_id:
+          type: integer
+        product_id:
+          type: integer
+        product_price_point_id:
+          type: integer
+        product_version:
+          type: integer
+        quantity:
+          type: string
+        subtotal_amount:
+          type: string
+        tax_amount:
+          type: string
+        tiered_unit_price:
+          type: boolean
+        title:
+          type: string
+        total_amount:
+          type: string
+        uid:
+          type: string
+        unit_price:
+          type: string
+      type: object
+    BillingLineItemsBreakouts:
+      properties:
+        discount_amount:
+          type: string
+        eligible_amount:
+          type: string
+        uid:
+          type: string
+      type: object
+    BillingPaymentProfile:
+      properties:
+        card_number:
+          type: string
+        card_type:
+          type: string
+        profile_id:
+          type: integer
+      type: object
+    BillingPayments:
+      properties:
+        applied_amount:
+          type: string
+        gateway_transaction_id:
+          type: string
+        memo:
+          description: Memo noted on the payment
+          type: string
+        original_amount:
+          type: string
+        payment_method:
+          items:
+            properties:
+              card_brand:
+                type: string
+              card_expiration:
+                type: string
+              details:
+                type: string
+              kind:
+                type: string
+              last_four:
+                type: string
+              masked_card_number:
+                type: string
+              memo:
+                description: Memo noted on the payment
+                type: string
+              type:
+                type: string
+            type: object
+          type: array
+        prepayment:
+          type: boolean
+        transaction_id:
+          type: integer
+        transaction_time:
+          type: string
+      type: object
+    BillingPrevBalanceData:
+      properties:
+        capture_date:
+          type: string
+        invoices:
+          items:
+            properties:
+              number:
+                type: string
+              outstanding_amount:
+                type: string
+              uid:
+                type: string
+            type: object
+          type: array
+      type: object
+    BillingRefunds:
+      properties:
+        applied_amount:
+          type: string
+        gateway_transaction_id:
+          description: Transaction ID for the refund as returned from the payment
+            gateway
+          type: string
+        memo:
+          description: Memo noted on refund
+          type: string
+        original_amount:
+          type: string
+        payment_id:
+          description: Payment ID to be refunded
+          type: integer
+        transaction_id:
+          type: integer
+      type: object
+    BillingTaxes:
+      properties:
+        line_items_breakouts:
+          items:
+            $ref: '#/components/schemas/BillingLineItemsBreakouts'
+          type: array
+        percentage:
+          type: string
+        source_id:
+          type: integer
+        source_type:
+          type: string
+        tax_amount:
+          type: string
+        taxable_amount:
+          type: string
+        title:
+          type: string
+        uid:
+          type: string
+      type: object
+    DbmodelKeyValue:
+      properties:
+        key:
+          type: string
+        type:
+          $ref: '#/components/schemas/DbmodelValueType'
+        value: {}
+      type: object
+    DbmodelLog:
+      properties:
+        fields:
+          items:
+            $ref: '#/components/schemas/DbmodelKeyValue'
+          nullable: true
+          type: array
+        timestamp:
+          minimum: 0
+          type: integer
+      type: object
+    DbmodelProcess:
+      properties:
+        serviceName:
+          type: string
+        tag:
+          additionalProperties: {}
+          type: object
+        tags:
+          items:
+            $ref: '#/components/schemas/DbmodelKeyValue'
+          nullable: true
+          type: array
+      type: object
+    DbmodelReference:
+      properties:
+        refType:
+          $ref: '#/components/schemas/DbmodelReferenceType'
+        spanID:
+          $ref: '#/components/schemas/DbmodelSpanID'
+        traceID:
+          $ref: '#/components/schemas/DbmodelTraceID'
+      type: object
+    DbmodelReferenceType:
+      type: string
+    DbmodelSpan:
+      properties:
+        duration:
+          minimum: 0
+          type: integer
+        flags:
+          minimum: 0
+          type: integer
+        logs:
+          items:
+            $ref: '#/components/schemas/DbmodelLog'
+          nullable: true
+          type: array
+        operationName:
+          type: string
+        parentSpanID:
+          $ref: '#/components/schemas/DbmodelSpanID'
+        process:
+          $ref: '#/components/schemas/DbmodelProcess'
+        references:
+          items:
+            $ref: '#/components/schemas/DbmodelReference'
+          nullable: true
+          type: array
+        spanID:
+          $ref: '#/components/schemas/DbmodelSpanID'
+        startTime:
+          minimum: 0
+          type: integer
+        startTimeMillis:
+          minimum: 0
+          type: integer
+        tag:
+          additionalProperties: {}
+          type: object
+        tags:
+          items:
+            $ref: '#/components/schemas/DbmodelKeyValue'
+          nullable: true
+          type: array
+        traceID:
+          $ref: '#/components/schemas/DbmodelTraceID'
+      type: object
+    DbmodelSpanID:
+      type: string
+    DbmodelTraceID:
+      type: string
+    DbmodelValueType:
+      type: string
+    DmeProtoAppPort:
+      properties:
+        end_port:
+          description: A non-zero end port indicates a port range from internal port
+            to end port, inclusive.
+          type: integer
+        fqdn_prefix:
+          description: FQDN prefix to append to base FQDN in FindCloudlet response.
+            May be empty.
+          type: string
+        internal_port:
+          description: Container port
+          type: integer
+        max_pkt_size:
+          description: Maximum datagram size (udp only)
+          type: integer
+        nginx:
+          description: Use nginx proxy for this port if you really need a transparent
+            proxy (udp only)
+          type: boolean
+        proto:
+          $ref: '#/components/schemas/DmeProtoLProto'
+        public_port:
+          description: Public facing port for TCP/UDP (may be mapped on shared LB
+            reverse proxy)
+          type: integer
+        tls:
+          description: TLS termination for this port
+          type: boolean
+      type: object
+    DmeProtoCloudletState:
+      type: integer
+    DmeProtoHealthCheck:
+      type: integer
+    DmeProtoLProto:
+      type: integer
+    DmeProtoLoc:
+      properties:
+        altitude:
+          description: On android only lat and long are guaranteed to be supplied
+            Altitude in meters
+          type: number
+        course:
+          description: Course (IOS) / bearing (Android) (degrees east relative to
+            true north)
+          type: number
+        horizontal_accuracy:
+          description: Horizontal accuracy (radius in meters)
+          type: number
+        latitude:
+          description: Latitude in WGS 84 coordinates
+          type: number
+        longitude:
+          description: Longitude in WGS 84 coordinates
+          type: number
+        speed:
+          description: Speed (IOS) / velocity (Android) (meters/sec)
+          type: number
+        timestamp:
+          $ref: '#/components/schemas/DmeProtoTimestamp'
+        vertical_accuracy:
+          description: Vertical accuracy (meters)
+          type: number
+      type: object
+    DmeProtoMaintenanceState:
+      type: integer
+    DmeProtoTimestamp:
+      properties:
+        nanos:
+          description: Added non-negative sub-second time in nanoseconds
+          type: integer
+        seconds:
+          description: Time in seconds since epoch
+          type: integer
+      type: object
+    EdgeprotoAlert:
+      properties:
+        active_at:
+          description: When alert became active
+          type: string
+        annotations:
+          additionalProperties:
+            type: string
+          description: Annotations are extra information about the alert
+          type: object
+        controller:
+          description: Connected controller unique id
+          type: string
+        labels:
+          additionalProperties:
+            type: string
+          description: Labels uniquely define the alert
+          type: object
+        notify_id:
+          description: Id of client assigned by server (internal use only)
+          type: integer
+        state:
+          description: State of the alert
+          type: string
+        value:
+          description: Any value associated with alert
+          type: number
+      type: object
+    EdgeprotoAlertPolicy:
+      properties:
+        active_conn_limit:
+          description: Active Connections alert threshold. Valid values 1-4294967295
+          minimum: 0
+          type: integer
+        annotations:
+          additionalProperties:
+            type: string
+          description: Additional Annotations for extra information about the alert
+          type: object
+        cpu_utilization_limit:
+          description: Container or pod CPU utilization rate(percentage) across all
+            nodes. Valid values 1-100
+          minimum: 0
+          type: integer
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        description:
+          description: Description of the alert policy
+          type: string
+        disk_utilization_limit:
+          description: Container or pod disk utilization rate(percentage) across all
+            nodes. Valid values 1-100
+          minimum: 0
+          type: integer
+        key:
+          $ref: '#/components/schemas/EdgeprotoAlertPolicyKey'
+        labels:
+          additionalProperties:
+            type: string
+          description: Additional Labels
+          type: object
+        mem_utilization_limit:
+          description: Container or pod memory utilization rate(percentage) across
+            all nodes. Valid values 1-100
+          minimum: 0
+          type: integer
+        severity:
+          description: Alert severity level - one of "info", "warning", "error"
+          type: string
+        trigger_time:
+          description: Duration for which alert interval is active (max 72 hours)
+          type: string
+      type: object
+    EdgeprotoAlertPolicyKey:
+      properties:
+        name:
+          description: Alert Policy name
+          type: string
+        organization:
+          description: Name of the organization for the app that this alert can be
+            applied to
+          type: string
+      type: object
+    EdgeprotoApp:
+      properties:
+        access_ports:
+          description: 'Comma separated list of protocol:port pairs that the App listens
+            on. Ex: "tcp:80,udp:10002". Also supports additional configurations per
+            port: (1) tls (tcp-only) - Enables TLS on specified port. Ex: "tcp:443:tls".
+            (2) nginx (udp-only) - Use NGINX LB instead of envoy for specified port.
+            Ex: "udp:10001:nginx". (3) maxpktsize (udp-only) - Configures maximum
+            UDP datagram size allowed on port for both upstream/downstream traffic.
+            Ex: "udp:10001:maxpktsize=8000".'
+          type: string
+        access_type:
+          description: (_deprecated_) Access type, valid values are one of DefaultForDeployment,
+            Direct, LoadBalancer, or 0, 1, 2
+          type: string
+        alert_policies:
+          description: Alert Policies
+          items:
+            type: string
+          type: array
+        allow_serverless:
+          description: App is allowed to deploy as serverless containers
+          type: boolean
+        android_package_name:
+          description: Android package name used to match the App name from the Android
+            package
+          type: string
+        annotations:
+          description: 'Annotations is a comma separated map of arbitrary key value
+            pairs, for example: key1=val1,key2=val2,key3="val 3"'
+          type: string
+        auth_public_key:
+          description: Public key used for authentication
+          type: string
+        auto_prov_policies:
+          description: Auto provisioning policy names, may be specified multiple times
+          items:
+            type: string
+          type: array
+        auto_prov_policy:
+          description: (_deprecated_) Auto provisioning policy name
+          type: string
+        command:
+          description: Command that the container runs to start service
+          type: string
+        configs:
+          description: Customization files passed through to implementing services
+          items:
+            $ref: '#/components/schemas/EdgeprotoConfigFile'
+          type: array
+        created_at:
+          description: Created at time
+          type: string
+        default_flavor:
+          $ref: '#/components/schemas/EdgeprotoFlavorKey'
+        del_opt:
+          description: Override actions to Controller, valid values are one of NoAutoDelete,
+            AutoDelete, or 0, 1
+          type: string
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        deployment:
+          description: Deployment type (kubernetes, docker, or vm)
+          type: string
+        deployment_generator:
+          description: Deployment generator target to generate a basic deployment
+            manifest
+          type: string
+        deployment_manifest:
+          description: Deployment manifest is the deployment specific manifest file/config.
+            For docker deployment, this can be a docker-compose or docker run file.
+            For kubernetes deployment, this can be a kubernetes yaml or helm chart
+            file.
+          type: string
+        image_path:
+          description: URI of where image resides
+          type: string
+        image_type:
+          description: Image type, valid values are one of Unknown, Docker, Qcow,
+            Helm, Ovf, or 0, 1, 2, 3, 4
+          type: string
+        internal_ports:
+          description: Set true to indicate App is used internally with other Apps
+            only, and no ports are exposed externally
+          type: boolean
+        key:
+          $ref: '#/components/schemas/EdgeprotoAppKey'
+        md5sum:
+          description: MD5Sum of the VM-based app image
+          type: string
+        official_fqdn:
+          description: Official FQDN is the FQDN that the app uses to connect by default
+          type: string
+        qos_session_duration:
+          description: Session duration in seconds. Maximal value of 24 hours is used
+            if not set
+          type: string
+        qos_session_profile:
+          description: Qualifier for the requested latency profile, valid values are
+            one of NoPriority, LowLatency, ThroughputDownS, ThroughputDownM, ThroughputDownL,
+            or 0, 1, 2, 3, 4
+          type: string
+        required_outbound_connections:
+          description: Connections this app require to determine if the app is compatible
+            with a trust policy
+          items:
+            $ref: '#/components/schemas/EdgeprotoSecurityRule'
+          nullable: true
+          type: array
+        revision:
+          description: Revision can be specified or defaults to current timestamp
+            when app is updated
+          type: string
+        scale_with_cluster:
+          description: Set true to run App on all nodes of the cluster
+          type: boolean
+        serverless_config:
+          $ref: '#/components/schemas/EdgeprotoServerlessConfig'
+        skip_hc_ports:
+          description: Comma separated list of protocol:port pairs that we should
+            not run health check on. Should be configured in case app does not always
+            listen on these ports. "all" can be specified if no health check to be
+            run for this app. Numerical values must be decimal format. i.e. tcp:80,udp:10002
+          type: string
+        template_delimiter:
+          description: Delimiter to be used for template parsing, defaults to "[[
+            ]]"
+          type: string
+        trusted:
+          description: Indicates that an instance of this app can be started on a
+            trusted cloudlet
+          type: boolean
+        updated_at:
+          description: Updated at time
+          type: string
+        vm_app_os_type:
+          description: OS Type for VM Apps, valid values are one of Unknown, Linux,
+            Windows10, Windows2012, Windows2016, Windows2019, or 0, 1, 2, 3, 4, 5
+          type: string
+      type: object
+    EdgeprotoAppAlertPolicy:
+      properties:
+        alert_policy:
+          description: Alert name
+          type: string
+        app_key:
+          $ref: '#/components/schemas/EdgeprotoAppKey'
+      type: object
+    EdgeprotoAppAutoProvPolicy:
+      properties:
+        app_key:
+          $ref: '#/components/schemas/EdgeprotoAppKey'
+        auto_prov_policy:
+          description: Auto provisioning policy name
+          type: string
+      type: object
+    EdgeprotoAppInst:
+      properties:
+        auto_cluster_ip_access:
+          description: (Deprecated) IpAccess for auto-clusters. Ignored otherwise.,
+            valid values are one of Unknown, Dedicated, Shared, or 0, 1, 3
+          type: string
+        availability_zone:
+          description: Optional Availability Zone if any
+          type: string
+        cloudlet_loc:
+          $ref: '#/components/schemas/DmeProtoLoc'
+        configs:
+          description: Customization files passed through to implementing services
+          items:
+            $ref: '#/components/schemas/EdgeprotoConfigFile'
+          type: array
+        created_at:
+          description: Created at time
+          type: string
+        crm_override:
+          description: Override actions to CRM, valid values are one of NoOverride,
+            IgnoreCrmErrors, IgnoreCrm, IgnoreTransientState, IgnoreCrmAndTransientState,
+            or 0, 1, 2, 3, 4
+          type: string
+        dedicated_ip:
+          description: Dedicated IP assigns an IP for this AppInst but requires platform
+            support
+          type: boolean
+        dns_label:
+          description: DNS label that is unique within the cloudlet and among other
+            AppInsts/ClusterInsts
+          type: string
+        errors:
+          description: Any errors trying to create, update, or delete the AppInst
+            on the Cloudlet
+          items:
+            type: string
+          type: array
+        external_volume_size:
+          description: Size of external volume to be attached to nodes.  This is for
+            the root partition
+          minimum: 0
+          type: integer
+        flavor:
+          $ref: '#/components/schemas/EdgeprotoFlavorKey'
+        force_update:
+          description: Force Appinst refresh even if revision number matches App revision
+            number.
+          type: boolean
+        health_check:
+          $ref: '#/components/schemas/DmeProtoHealthCheck'
+        internal_port_to_lb_ip:
+          additionalProperties:
+            type: string
+          description: mapping of ports to load balancer IPs
+          type: object
+        key:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        liveness:
+          description: Liveness of instance (see Liveness), valid values are one of
+            Unknown, Static, Dynamic, Autoprov, or 0, 1, 2, 3
+          type: string
+        mapped_ports:
+          description: For instances accessible via a shared load balancer, defines
+            the external ports on the shared load balancer that map to the internal
+            ports External ports should be appended to the Uri for L4 access.
+          items:
+            $ref: '#/components/schemas/DmeProtoAppPort'
+          nullable: true
+          type: array
+        opt_res:
+          description: Optional Resources required by OS flavor if any
+          type: string
+        power_state:
+          description: Power State of the AppInst, valid values are one of PowerStateUnknown,
+            PowerOnRequested, PoweringOn, PowerOn, PowerOffRequested, PoweringOff,
+            PowerOff, RebootRequested, Rebooting, Reboot, PowerStateError, or 0, 1,
+            2, 3, 4, 5, 6, 7, 8, 9, 10
+          type: string
+        real_cluster_name:
+          description: Real ClusterInst name
+          type: string
+        revision:
+          description: Revision changes each time the App is updated.  Refreshing
+            the App Instance will sync the revision with that of the App
+          type: string
+        runtime_info:
+          $ref: '#/components/schemas/EdgeprotoAppInstRuntime'
+        state:
+          description: Current state of the AppInst on the Cloudlet, valid values
+            are one of TrackedStateUnknown, NotPresent, CreateRequested, Creating,
+            CreateError, Ready, UpdateRequested, Updating, UpdateError, DeleteRequested,
+            Deleting, DeleteError, DeletePrepare, CrmInitok, CreatingDependencies,
+            DeleteDone, or 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+          type: string
+        unique_id:
+          description: A unique id for the AppInst within the region to be used by
+            platforms
+          type: string
+        update_multiple:
+          description: Allow multiple instances to be updated at once
+          type: boolean
+        updated_at:
+          description: Updated at time
+          type: string
+        uri:
+          description: Base FQDN (not really URI) for the App. See Service FQDN for
+            endpoint access.
+          type: string
+        vm_flavor:
+          description: OS node flavor to use
+          type: string
+      type: object
+    EdgeprotoAppInstClient:
+      properties:
+        client_key:
+          $ref: '#/components/schemas/EdgeprotoAppInstClientKey'
+        location:
+          $ref: '#/components/schemas/DmeProtoLoc'
+        notify_id:
+          description: Id of client assigned by server (internal use only)
+          type: integer
+      type: object
+    EdgeprotoAppInstClientKey:
+      properties:
+        app_inst_key:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        unique_id:
+          description: AppInstClient Unique Id
+          type: string
+        unique_id_type:
+          description: AppInstClient Unique Id Type
+          type: string
+      type: object
+    EdgeprotoAppInstKey:
+      properties:
+        app_key:
+          $ref: '#/components/schemas/EdgeprotoAppKey'
+        cluster_inst_key:
+          $ref: '#/components/schemas/EdgeprotoVirtualClusterInstKey'
+      type: object
+    EdgeprotoAppInstLatency:
+      properties:
+        key:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+      type: object
+    EdgeprotoAppInstRefKey:
+      properties:
+        app_key:
+          $ref: '#/components/schemas/EdgeprotoAppKey'
+        cluster_inst_key:
+          $ref: '#/components/schemas/EdgeprotoClusterInstRefKey'
+      type: object
+    EdgeprotoAppInstRefs:
+      properties:
+        delete_requested_insts:
+          additionalProperties:
+            minimum: 0
+            type: integer
+          description: AppInsts being deleted (key is JSON of AppInst Key)
+          nullable: true
+          type: object
+        insts:
+          additionalProperties:
+            minimum: 0
+            type: integer
+          description: AppInsts for App (key is JSON of AppInst Key)
+          nullable: true
+          type: object
+        key:
+          $ref: '#/components/schemas/EdgeprotoAppKey'
+      type: object
+    EdgeprotoAppInstRuntime:
+      properties:
+        container_ids:
+          description: List of container names
+          items:
+            type: string
+          type: array
+      type: object
+    EdgeprotoAppKey:
+      properties:
+        name:
+          description: App name
+          type: string
+        organization:
+          description: App developer organization
+          type: string
+        version:
+          description: App version
+          type: string
+      type: object
+    EdgeprotoAutoProvCloudlet:
+      properties:
+        key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        loc:
+          $ref: '#/components/schemas/DmeProtoLoc'
+      type: object
+    EdgeprotoAutoProvPolicy:
+      properties:
+        cloudlets:
+          description: Allowed deployment locations
+          items:
+            $ref: '#/components/schemas/EdgeprotoAutoProvCloudlet'
+          type: array
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        deploy_client_count:
+          description: Minimum number of clients within the auto deploy interval to
+            trigger deployment
+          minimum: 0
+          type: integer
+        deploy_interval_count:
+          description: Number of intervals to check before triggering deployment
+          minimum: 0
+          type: integer
+        key:
+          $ref: '#/components/schemas/EdgeprotoPolicyKey'
+        max_instances:
+          description: Maximum number of instances (active or not)
+          minimum: 0
+          type: integer
+        min_active_instances:
+          description: Minimum number of active instances for High-Availability
+          minimum: 0
+          type: integer
+        undeploy_client_count:
+          description: Number of active clients for the undeploy interval below which
+            trigers undeployment, 0 (default) disables auto undeploy
+          minimum: 0
+          type: integer
+        undeploy_interval_count:
+          description: Number of intervals to check before triggering undeployment
+          minimum: 0
+          type: integer
+      type: object
+    EdgeprotoAutoProvPolicyCloudlet:
+      properties:
+        cloudlet_key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        key:
+          $ref: '#/components/schemas/EdgeprotoPolicyKey'
+      type: object
+    EdgeprotoAutoScalePolicy:
+      properties:
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        key:
+          $ref: '#/components/schemas/EdgeprotoPolicyKey'
+        max_nodes:
+          description: Maximum number of cluster nodes
+          minimum: 0
+          type: integer
+        min_nodes:
+          description: Minimum number of cluster nodes
+          minimum: 0
+          type: integer
+        scale_down_cpu_thresh:
+          description: (Deprecated) Scale down cpu threshold (percentage 1 to 100),
+            0 means disabled
+          minimum: 0
+          type: integer
+        scale_up_cpu_thresh:
+          description: (Deprecated) Scale up cpu threshold (percentage 1 to 100),
+            0 means disabled
+          minimum: 0
+          type: integer
+        stabilization_window_sec:
+          description: Stabilization window is the time for which past triggers are
+            considered; the largest scale factor is always taken.
+          minimum: 0
+          type: integer
+        target_active_connections:
+          description: Target per-node number of active connections, 0 means disabled
+          minimum: 0
+          type: integer
+        target_cpu:
+          description: Target per-node cpu utilization (percentage 1 to 100), 0 means
+            disabled
+          minimum: 0
+          type: integer
+        target_mem:
+          description: Target per-node memory utilization (percentage 1 to 100), 0
+            means disabled
+          minimum: 0
+          type: integer
+        trigger_time_sec:
+          description: (Deprecated) Trigger time defines how long the target must
+            be satified in seconds before acting upon it.
+          minimum: 0
+          type: integer
+      type: object
+    EdgeprotoCloudlet:
+      properties:
+        HostController:
+          description: Address of the controller hosting the cloudlet services if
+            it is running locally
+          type: string
+        access_vars:
+          additionalProperties:
+            type: string
+          description: Variables required to access cloudlet
+          type: object
+        alliance_orgs:
+          description: This cloudlet will be treated as directly connected to these
+            additional operator organizations for the purposes of FindCloudlet
+          items:
+            type: string
+          type: array
+        chef_client_key:
+          additionalProperties:
+            type: string
+          description: Chef client key
+          type: object
+        config:
+          $ref: '#/components/schemas/EdgeprotoPlatformConfig'
+        container_version:
+          description: Cloudlet container version
+          type: string
+        created_at:
+          description: Created at time
+          type: string
+        crm_access_key_upgrade_required:
+          description: CRM access key upgrade required
+          type: boolean
+        crm_access_public_key:
+          description: CRM access public key
+          type: string
+        crm_override:
+          description: Override actions to CRM, valid values are one of NoOverride,
+            IgnoreCrmErrors, IgnoreCrm, IgnoreTransientState, IgnoreCrmAndTransientState,
+            or 0, 1, 2, 3, 4
+          type: string
+        default_resource_alert_threshold:
+          description: Default resource alert threshold percentage
+          type: integer
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        deployment:
+          description: Deployment type to bring up CRM services (docker, kubernetes)
+          type: string
+        deployment_local:
+          description: Deploy cloudlet services locally
+          type: boolean
+        dns_label:
+          description: DNS label that is unique within the region
+          type: string
+        enable_default_serverless_cluster:
+          description: Enable experimental default multitenant (serverless) cluster
+          type: boolean
+        env_var:
+          additionalProperties:
+            type: string
+          description: Single Key-Value pair of env var to be passed to CRM
+          type: object
+        errors:
+          description: Any errors trying to create, update, or delete the Cloudlet.
+          items:
+            type: string
+          type: array
+        federation_config:
+          $ref: '#/components/schemas/EdgeprotoFederationConfig'
+        fields:
+          description: Fields are used for the Update API to specify which fields
+            to apply
+          items:
+            type: string
+          type: array
+        flavor:
+          $ref: '#/components/schemas/EdgeprotoFlavorKey'
+        gpu_config:
+          $ref: '#/components/schemas/EdgeprotoGPUConfig'
+        infra_api_access:
+          description: Infra Access Type is the type of access available to Infra
+            API Endpoint, valid values are one of DirectAccess, RestrictedAccess,
+            or 0, 1
+          type: string
+        infra_config:
+          $ref: '#/components/schemas/EdgeprotoInfraConfig'
+        ip_support:
+          description: Type of IP support provided by Cloudlet (see IpSupport), valid
+            values are one of Unknown, Static, Dynamic, or 0, 1, 2
+          type: string
+        kafka_cluster:
+          description: Operator provided kafka cluster endpoint to push events to
+          type: string
+        kafka_password:
+          description: Password for kafka SASL/PLAIN authentification, stored securely
+            in secret storage and never visible externally
+          type: string
+        kafka_user:
+          description: Username for kafka SASL/PLAIN authentification, stored securely
+            in secret storage and never visible externally
+          type: string
+        key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        license_config_storage_path:
+          description: GPU driver license config storage path
+          type: string
+        location:
+          $ref: '#/components/schemas/DmeProtoLoc'
+        maintenance_state:
+          $ref: '#/components/schemas/DmeProtoMaintenanceState'
+        notify_srv_addr:
+          description: Address for the CRM notify listener to run on
+          type: string
+        num_dynamic_ips:
+          description: Number of dynamic IPs available for dynamic IP support
+          type: integer
+        override_policy_container_version:
+          description: Override container version from policy file
+          type: boolean
+        physical_name:
+          description: Physical infrastructure cloudlet name
+          type: string
+        platform_high_availability:
+          description: Enable platform H/A
+          type: boolean
+        platform_type:
+          description: Platform type, valid values are one of Fake, Dind, Openstack,
+            Azure, Gcp, Edgebox, Fakeinfra, Vsphere, AwsEks, VmPool, AwsEc2, Vcd,
+            K8SBareMetal, Kind, Kindinfra, FakeSingleCluster, Federation, FakeVmPool,
+            or 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17
+          type: string
+        res_tag_map:
+          additionalProperties:
+            $ref: '#/components/schemas/EdgeprotoResTagTableKey'
+          description: Optional resource to restagtbl key map key values = [gpu, nas,
+            nic]
+          type: object
+        resource_quotas:
+          description: Resource quotas
+          items:
+            $ref: '#/components/schemas/EdgeprotoResourceQuota'
+          nullable: true
+          type: array
+        root_lb_fqdn:
+          description: Root LB FQDN which is globally unique
+          type: string
+        secondary_crm_access_key_upgrade_required:
+          description: CRM secondary access key upgrade required for H/A
+          type: boolean
+        secondary_crm_access_public_key:
+          description: CRM secondary access public key for H/A
+          type: string
+        secondary_notify_srv_addr:
+          description: Address for the secondary CRM notify listener to run on
+          type: string
+        single_kubernetes_cluster_owner:
+          description: For single kubernetes cluster cloudlet platforms, cluster is
+            owned by this organization instead of multi-tenant
+          type: string
+        state:
+          description: Current state of the cloudlet, valid values are one of TrackedStateUnknown,
+            NotPresent, CreateRequested, Creating, CreateError, Ready, UpdateRequested,
+            Updating, UpdateError, DeleteRequested, Deleting, DeleteError, DeletePrepare,
+            CrmInitok, CreatingDependencies, DeleteDone, or 0, 1, 2, 3, 4, 5, 6, 7,
+            8, 9, 10, 11, 12, 13, 14, 15
+          type: string
+        static_ips:
+          description: List of static IPs for static IP support
+          type: string
+        time_limits:
+          $ref: '#/components/schemas/EdgeprotoOperationTimeLimits'
+        trust_policy:
+          description: Optional Trust Policy
+          type: string
+        trust_policy_state:
+          description: State of trust policy, valid values are one of TrackedStateUnknown,
+            NotPresent, CreateRequested, Creating, CreateError, Ready, UpdateRequested,
+            Updating, UpdateError, DeleteRequested, Deleting, DeleteError, DeletePrepare,
+            CrmInitok, CreatingDependencies, DeleteDone, or 0, 1, 2, 3, 4, 5, 6, 7,
+            8, 9, 10, 11, 12, 13, 14, 15
+          type: string
+        updated_at:
+          description: Updated at time
+          type: string
+        vm_image_version:
+          description: EdgeCloud baseimage version where CRM services reside
+          type: string
+        vm_pool:
+          description: VM Pool
+          type: string
+      type: object
+    EdgeprotoCloudletAllianceOrg:
+      properties:
+        key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        organization:
+          description: Alliance organization
+          type: string
+      type: object
+    EdgeprotoCloudletInfo:
+      properties:
+        active_crm_instance:
+          description: Active HA instance
+          type: string
+        availability_zones:
+          description: Availability Zones if any
+          items:
+            $ref: '#/components/schemas/EdgeprotoOSAZone'
+          type: array
+        compatibility_version:
+          description: Version for compatibility tracking
+          minimum: 0
+          type: integer
+        container_version:
+          description: Cloudlet container version
+          type: string
+        controller:
+          description: Connected controller unique id
+          type: string
+        controller_cache_received:
+          description: Indicates all controller data has been sent to CRM
+          type: boolean
+        errors:
+          description: Any errors encountered while making changes to the Cloudlet
+          items:
+            type: string
+          type: array
+        flavors:
+          description: Supported flavors by the Cloudlet
+          items:
+            $ref: '#/components/schemas/EdgeprotoFlavorInfo'
+          type: array
+        key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        maintenance_state:
+          $ref: '#/components/schemas/DmeProtoMaintenanceState'
+        node_infos:
+          description: Cluster node info for serverless platforms (k8s multi-tenant
+            cluster)
+          items:
+            $ref: '#/components/schemas/EdgeprotoNodeInfo'
+          type: array
+        notify_id:
+          description: Id of client assigned by server (internal use only)
+          type: integer
+        os_images:
+          description: Local Images availble to cloudlet
+          items:
+            $ref: '#/components/schemas/EdgeprotoOSImage'
+          type: array
+        os_max_ram:
+          description: Maximum Ram in MB on the Cloudlet
+          minimum: 0
+          type: integer
+        os_max_vcores:
+          description: Maximum number of VCPU cores on the Cloudlet
+          minimum: 0
+          type: integer
+        os_max_vol_gb:
+          description: Maximum amount of disk in GB on the Cloudlet
+          minimum: 0
+          type: integer
+        properties:
+          additionalProperties:
+            type: string
+          description: Cloudlet properties
+          type: object
+        release_version:
+          description: Cloudlet release version
+          type: string
+        resources_snapshot:
+          $ref: '#/components/schemas/EdgeprotoInfraResourcesSnapshot'
+        standby_crm:
+          description: Denotes if info was reported by inactive
+          type: boolean
+        state:
+          $ref: '#/components/schemas/DmeProtoCloudletState'
+        trust_policy_state:
+          description: Trust Policy State, valid values are one of TrackedStateUnknown,
+            NotPresent, CreateRequested, Creating, CreateError, Ready, UpdateRequested,
+            Updating, UpdateError, DeleteRequested, Deleting, DeleteError, DeletePrepare,
+            CrmInitok, CreatingDependencies, DeleteDone, or 0, 1, 2, 3, 4, 5, 6, 7,
+            8, 9, 10, 11, 12, 13, 14, 15
+          type: string
+      type: object
+    EdgeprotoCloudletKey:
+      properties:
+        federated_organization:
+          description: Federated operator organization who shared this cloudlet
+          type: string
+        name:
+          description: Name of the cloudlet
+          type: string
+        organization:
+          description: Organization of the cloudlet site
+          type: string
+      type: object
+    EdgeprotoCloudletManifest:
+      properties:
+        manifest:
+          description: Manifest to bringup cloudlet VM and services.
+          type: string
+      type: object
+    EdgeprotoCloudletMgmtNode:
+      properties:
+        name:
+          description: Name of Cloudlet Mgmt Node
+          type: string
+        type:
+          description: Type of Cloudlet Mgmt Node
+          type: string
+      type: object
+    EdgeprotoCloudletPool:
+      properties:
+        cloudlets:
+          description: Cloudlets part of the pool
+          items:
+            $ref: '#/components/schemas/EdgeprotoCloudletKey'
+          nullable: true
+          type: array
+        created_at:
+          description: Created at time
+          type: string
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        key:
+          $ref: '#/components/schemas/EdgeprotoCloudletPoolKey'
+        updated_at:
+          description: Updated at time
+          type: string
+      type: object
+    EdgeprotoCloudletPoolKey:
+      properties:
+        name:
+          description: CloudletPool Name
+          type: string
+        organization:
+          description: Name of the organization this pool belongs to
+          type: string
+      type: object
+    EdgeprotoCloudletPoolMember:
+      properties:
+        cloudlet:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        key:
+          $ref: '#/components/schemas/EdgeprotoCloudletPoolKey'
+      type: object
+    EdgeprotoCloudletProps:
+      properties:
+        organization:
+          description: Organization
+          type: string
+        platform_type:
+          description: Platform type, valid values are one of Fake, Dind, Openstack,
+            Azure, Gcp, Edgebox, Fakeinfra, Vsphere, AwsEks, VmPool, AwsEc2, Vcd,
+            K8SBareMetal, Kind, Kindinfra, FakeSingleCluster, Federation, FakeVmPool,
+            or 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17
+          type: string
+        properties:
+          additionalProperties:
+            $ref: '#/components/schemas/EdgeprotoPropertyInfo'
+          description: Single Key-Value pair of env var to be passed to CRM
+          type: object
+      type: object
+    EdgeprotoCloudletRefs:
+      properties:
+        cluster_insts:
+          description: Clusters instantiated on the Cloudlet
+          items:
+            $ref: '#/components/schemas/EdgeprotoClusterInstRefKey'
+          nullable: true
+          type: array
+        k8s_app_insts:
+          description: K8s apps instantiated on the Cloudlet
+          items:
+            $ref: '#/components/schemas/EdgeprotoAppInstRefKey'
+          nullable: true
+          type: array
+        key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        opt_res_used_map:
+          additionalProperties:
+            minimum: 0
+            type: integer
+          description: Used Optional Resources
+          type: object
+        reserved_auto_cluster_ids:
+          description: Track reservable autoclusterinsts ids in use. This is a bitmap.
+          minimum: 0
+          type: integer
+        root_lb_ports:
+          additionalProperties:
+            type: integer
+          description: 'Used ports on root load balancer. Map key is public port,
+            value is a bitmap for the protocol bitmap: bit 0: tcp, bit 1: udp'
+          type: object
+        used_dynamic_ips:
+          description: Used dynamic IPs
+          type: integer
+        used_static_ips:
+          description: Used static IPs
+          type: string
+        vm_app_insts:
+          description: VM apps instantiated on the Cloudlet
+          items:
+            $ref: '#/components/schemas/EdgeprotoAppInstRefKey'
+          nullable: true
+          type: array
+      type: object
+    EdgeprotoCloudletResMap:
+      properties:
+        key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        mapping:
+          additionalProperties:
+            type: string
+          description: Resource mapping info
+          type: object
+      type: object
+    EdgeprotoCloudletResourceQuotaProps:
+      properties:
+        organization:
+          description: Organization
+          type: string
+        platform_type:
+          description: Platform type, valid values are one of Fake, Dind, Openstack,
+            Azure, Gcp, Edgebox, Fakeinfra, Vsphere, AwsEks, VmPool, AwsEc2, Vcd,
+            K8SBareMetal, Kind, Kindinfra, FakeSingleCluster, Federation, FakeVmPool,
+            or 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17
+          type: string
+        properties:
+          description: Cloudlet resource properties
+          items:
+            $ref: '#/components/schemas/EdgeprotoInfraResource'
+          nullable: true
+          type: array
+      type: object
+    EdgeprotoCloudletResourceUsage:
+      properties:
+        info:
+          description: Infra Resource information
+          items:
+            $ref: '#/components/schemas/EdgeprotoInfraResource'
+          nullable: true
+          type: array
+        infra_usage:
+          description: Show Infra based usage
+          type: boolean
+        key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+      type: object
+    EdgeprotoClusterInst:
+      properties:
+        allocated_ip:
+          description: Allocated IP for dedicated access
+          type: string
+        auto:
+          description: Auto is set to true when automatically created by back-end
+            (internal use only)
+          type: boolean
+        auto_scale_policy:
+          description: Auto scale policy name
+          type: string
+        availability_zone:
+          description: Optional Resource AZ if any
+          type: string
+        created_at:
+          description: Created at time
+          type: string
+        crm_override:
+          description: Override actions to CRM, valid values are one of NoOverride,
+            IgnoreCrmErrors, IgnoreCrm, IgnoreTransientState, IgnoreCrmAndTransientState,
+            or 0, 1, 2, 3, 4
+          type: string
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        deployment:
+          description: Deployment type (kubernetes or docker)
+          type: string
+        dns_label:
+          description: DNS label that is unique within the cloudlet and among other
+            AppInsts/ClusterInsts
+          type: string
+        errors:
+          description: Any errors trying to create, update, or delete the ClusterInst
+            on the Cloudlet.
+          items:
+            type: string
+          type: array
+        external_volume_size:
+          description: Size of external volume to be attached to nodes.  This is for
+            the root partition
+          minimum: 0
+          type: integer
+        flavor:
+          $ref: '#/components/schemas/EdgeprotoFlavorKey'
+        fqdn:
+          description: FQDN is a globally unique DNS id for the ClusterInst
+          type: string
+        image_name:
+          description: Optional resource specific image to launch
+          type: string
+        ip_access:
+          description: IP access type (RootLB Type), valid values are one of Unknown,
+            Dedicated, Shared, or 0, 1, 3
+          type: string
+        key:
+          $ref: '#/components/schemas/EdgeprotoClusterInstKey'
+        liveness:
+          description: Liveness of instance (see Liveness), valid values are one of
+            Unknown, Static, Dynamic, Autoprov, or 0, 1, 2, 3
+          type: string
+        master_node_flavor:
+          description: Generic flavor for k8s master VM when worker nodes > 0
+          type: string
+        multi_tenant:
+          description: Multi-tenant kubernetes cluster
+          type: boolean
+        networks:
+          description: networks to connect to
+          items:
+            type: string
+          type: array
+        node_flavor:
+          description: Cloudlet specific node flavor
+          type: string
+        num_masters:
+          description: Number of k8s masters (In case of docker deployment, this field
+            is not required)
+          minimum: 0
+          type: integer
+        num_nodes:
+          description: Number of k8s nodes (In case of docker deployment, this field
+            is not required)
+          minimum: 0
+          type: integer
+        opt_res:
+          description: Optional Resources required by OS flavor if any
+          type: string
+        reservable:
+          description: If ClusterInst is reservable
+          type: boolean
+        reservation_ended_at:
+          description: For reservable ClusterInsts, when the last reservation ended
+          type: string
+        reserved_by:
+          description: For reservable EdgeCloud ClusterInsts, the current developer
+            tenant
+          type: string
+        resources:
+          $ref: '#/components/schemas/EdgeprotoInfraResources'
+        shared_volume_size:
+          description: Size of an optional shared volume to be mounted on the master
+          minimum: 0
+          type: integer
+        skip_crm_cleanup_on_failure:
+          description: Prevents cleanup of resources on failure within CRM, used for
+            diagnostic purposes
+          type: boolean
+        state:
+          description: State of the cluster instance, valid values are one of TrackedStateUnknown,
+            NotPresent, CreateRequested, Creating, CreateError, Ready, UpdateRequested,
+            Updating, UpdateError, DeleteRequested, Deleting, DeleteError, DeletePrepare,
+            CrmInitok, CreatingDependencies, DeleteDone, or 0, 1, 2, 3, 4, 5, 6, 7,
+            8, 9, 10, 11, 12, 13, 14, 15
+          type: string
+        updated_at:
+          description: Updated at time
+          type: string
+      type: object
+    EdgeprotoClusterInstKey:
+      properties:
+        cloudlet_key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        cluster_key:
+          $ref: '#/components/schemas/EdgeprotoClusterKey'
+        organization:
+          description: Name of Developer organization that this cluster belongs to
+          type: string
+      type: object
+    EdgeprotoClusterInstRefKey:
+      properties:
+        cluster_key:
+          $ref: '#/components/schemas/EdgeprotoClusterKey'
+        organization:
+          description: Name of Developer organization that this cluster belongs to
+          type: string
+      type: object
+    EdgeprotoClusterKey:
+      properties:
+        name:
+          description: Cluster name
+          type: string
+      type: object
+    EdgeprotoClusterRefs:
+      properties:
+        apps:
+          description: App instances in the Cluster Instance
+          items:
+            $ref: '#/components/schemas/EdgeprotoClusterRefsAppInstKey'
+          nullable: true
+          type: array
+        key:
+          $ref: '#/components/schemas/EdgeprotoClusterInstKey'
+      type: object
+    EdgeprotoClusterRefsAppInstKey:
+      properties:
+        app_key:
+          $ref: '#/components/schemas/EdgeprotoAppKey'
+        v_cluster_name:
+          description: Virtual cluster name
+          type: string
+      type: object
+    EdgeprotoCollectionInterval:
+      properties:
+        interval:
+          description: Collection interval for Influxdb (Specifically used for continuous
+            query intervals) (Data from old continuous queries will be inaccessible
+            if intervals are updated)
+          type: string
+        retention:
+          description: Retention duration for Influxdb interval (0 uses default retention
+            policy)
+          type: string
+      type: object
+    EdgeprotoConfigFile:
+      properties:
+        config:
+          description: Config file contents or URI reference
+          type: string
+        kind:
+          description: Kind (type) of config, i.e. envVarsYaml, helmCustomizationYaml
+          type: string
+      type: object
+    EdgeprotoContainerInfo:
+      properties:
+        clusterip:
+          description: IP within the CNI and is applicable to kubernetes only
+          type: string
+        name:
+          description: Name of the container
+          type: string
+        restarts:
+          description: Restart count, applicable to kubernetes only
+          type: integer
+        status:
+          description: Runtime status of the container
+          type: string
+        type:
+          description: Type can be docker or kubernetes
+          type: string
+      type: object
+    EdgeprotoDebugReply:
+      properties:
+        node:
+          $ref: '#/components/schemas/EdgeprotoNodeKey'
+        output:
+          description: Debug output, if any
+          type: string
+      type: object
+    EdgeprotoDebugRequest:
+      properties:
+        args:
+          description: Additional arguments for cmd
+          type: string
+        cmd:
+          description: Debug command (use "help" to see available commands)
+          type: string
+        id:
+          description: Id used internally
+          minimum: 0
+          type: integer
+        levels:
+          description: 'Comma separated list of debug level names: etcd,api,notify,dmereq,locapi,infra,metrics,upgrade,info,sampled,fedapi'
+          type: string
+        node:
+          $ref: '#/components/schemas/EdgeprotoNodeKey'
+        pretty:
+          description: if possible, make output pretty
+          type: boolean
+        timeout:
+          description: custom timeout (duration, defaults to 10s)
+          type: string
+      type: object
+    EdgeprotoDeploymentCloudletRequest:
+      properties:
+        app:
+          $ref: '#/components/schemas/EdgeprotoApp'
+        dry_run_deploy:
+          description: Attempt to qualify cloudlet resources for deployment
+          type: boolean
+        num_nodes:
+          description: Optional number of worker VMs in dry run K8s Cluster, default
+            = 2
+          minimum: 0
+          type: integer
+      type: object
+    EdgeprotoDevice:
+      properties:
+        first_seen:
+          $ref: '#/components/schemas/TypesTimestamp'
+        key:
+          $ref: '#/components/schemas/EdgeprotoDeviceKey'
+        last_seen:
+          $ref: '#/components/schemas/TypesTimestamp'
+        notify_id:
+          description: Id of client assigned by server (internal use only)
+          type: integer
+      type: object
+    EdgeprotoDeviceKey:
+      properties:
+        unique_id:
+          description: Unique identification of the client device or user. May be
+            overridden by the server.
+          type: string
+        unique_id_type:
+          description: Type of unique ID provided by the client
+          type: string
+      type: object
+    EdgeprotoDeviceReport:
+      properties:
+        begin:
+          $ref: '#/components/schemas/TypesTimestamp'
+        end:
+          $ref: '#/components/schemas/TypesTimestamp'
+        key:
+          $ref: '#/components/schemas/EdgeprotoDeviceKey'
+      type: object
+    EdgeprotoExecRequest:
+      properties:
+        access_url:
+          description: Access URL
+          type: string
+        answer:
+          description: Answer
+          type: string
+        app_inst_key:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        cmd:
+          $ref: '#/components/schemas/EdgeprotoRunCmd'
+        console:
+          $ref: '#/components/schemas/EdgeprotoRunVMConsole'
+        container_id:
+          description: ContainerId is the name or ID of the target container, if applicable
+          type: string
+        edge_turn_addr:
+          description: EdgeTurn Server Address
+          type: string
+        err:
+          description: Any error message
+          type: string
+        log:
+          $ref: '#/components/schemas/EdgeprotoShowLog'
+        offer:
+          description: Offer
+          type: string
+        timeout:
+          description: Timeout
+          type: string
+      type: object
+    EdgeprotoFederationConfig:
+      properties:
+        federation_name:
+          description: Federation name
+          type: string
+        partner_federation_addr:
+          description: Partner federation address
+          type: string
+        partner_federation_id:
+          description: Partner federation ID
+          type: string
+        self_federation_id:
+          description: Self federation ID
+          type: string
+        zone_country_code:
+          description: Cloudlet zone country code
+          type: string
+      type: object
+    EdgeprotoFlavor:
+      properties:
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        disk:
+          description: Amount of disk space in gigabytes
+          minimum: 0
+          type: integer
+        key:
+          $ref: '#/components/schemas/EdgeprotoFlavorKey'
+        opt_res_map:
+          additionalProperties:
+            type: string
+          description: 'Optional Resources request, key = gpu form: $resource=$kind:[$alias]$count
+            ex: optresmap=gpu=vgpu:nvidia-63:1'
+          type: object
+        ram:
+          description: RAM in megabytes
+          minimum: 0
+          type: integer
+        vcpus:
+          description: Number of virtual CPUs
+          minimum: 0
+          type: integer
+      type: object
+    EdgeprotoFlavorInfo:
+      properties:
+        disk:
+          description: Amount of disk in GB on the Cloudlet
+          minimum: 0
+          type: integer
+        name:
+          description: Name of the flavor on the Cloudlet
+          type: string
+        prop_map:
+          additionalProperties:
+            type: string
+          description: OS Flavor Properties, if any
+          type: object
+        ram:
+          description: Ram in MB on the Cloudlet
+          minimum: 0
+          type: integer
+        vcpus:
+          description: Number of VCPU cores on the Cloudlet
+          minimum: 0
+          type: integer
+      type: object
+    EdgeprotoFlavorKey:
+      properties:
+        name:
+          description: Flavor name
+          type: string
+      type: object
+    EdgeprotoFlavorMatch:
+      properties:
+        availability_zone:
+          description: availability zone for optional resources if any
+          type: string
+        flavor_name:
+          description: Flavor name to lookup
+          type: string
+        key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+      type: object
+    EdgeprotoFlowRateLimitSettings:
+      properties:
+        key:
+          $ref: '#/components/schemas/EdgeprotoFlowRateLimitSettingsKey'
+        settings:
+          $ref: '#/components/schemas/EdgeprotoFlowSettings'
+      type: object
+    EdgeprotoFlowRateLimitSettingsKey:
+      properties:
+        flow_settings_name:
+          description: Unique name for FlowRateLimitSettings (there can be multiple
+            FlowSettings per RateLimitSettingsKey)
+          type: string
+        rate_limit_key:
+          $ref: '#/components/schemas/EdgeprotoRateLimitSettingsKey'
+      type: object
+    EdgeprotoFlowSettings:
+      properties:
+        burst_size:
+          description: Burst size for flow rate limiting (required for TokenBucketAlgorithm)
+          type: integer
+        flow_algorithm:
+          description: Flow Rate Limit algorithm, valid values are one of UnknownFlowAlgorithm,
+            TokenBucketAlgorithm, LeakyBucketAlgorithm, or 0, 1, 2
+          type: string
+        reqs_per_second:
+          description: Requests per second for flow rate limiting
+          type: number
+      type: object
+    EdgeprotoGPUConfig:
+      properties:
+        driver:
+          $ref: '#/components/schemas/EdgeprotoGPUDriverKey'
+        license_config:
+          description: Cloudlet specific license config to setup license (will be
+            stored in secure storage)
+          type: string
+        license_config_md5sum:
+          description: Cloudlet specific license config md5sum, to ensure integrity
+            of license config
+          type: string
+        properties:
+          additionalProperties:
+            type: string
+          description: Properties to identify specifics of GPU
+          type: object
+      type: object
+    EdgeprotoGPUDriver:
+      properties:
+        builds:
+          description: List of GPU driver build
+          items:
+            $ref: '#/components/schemas/EdgeprotoGPUDriverBuild'
+          nullable: true
+          type: array
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        ignore_state:
+          description: Ignore state will ignore any action in-progress on the GPU
+            driver
+          type: boolean
+        key:
+          $ref: '#/components/schemas/EdgeprotoGPUDriverKey'
+        license_config:
+          description: License config to setup license (will be stored in secure storage)
+          type: string
+        license_config_md5sum:
+          description: License config md5sum, to ensure integrity of license config
+          type: string
+        license_config_storage_path:
+          description: GPU driver license config storage path
+          type: string
+        properties:
+          additionalProperties:
+            type: string
+          description: 'Additional properties associated with GPU driver build For
+            example: license server information, driver release date, etc'
+          type: object
+        state:
+          description: State to figure out if any action on the GPU driver is in-progress
+          type: string
+        storage_bucket_name:
+          description: GPU driver storage bucket name
+          type: string
+      type: object
+    EdgeprotoGPUDriverBuild:
+      properties:
+        driver_path:
+          description: Path where the driver package is located, if it is authenticated
+            path, then credentials must be passed as part of URL (one-time download
+            path)
+          type: string
+        driver_path_creds:
+          description: Optional credentials (username:password) to access driver path
+          type: string
+        hypervisor_info:
+          description: Info on hypervisor supported by vGPU driver
+          type: string
+        kernel_version:
+          description: Kernel Version supported by GPU driver build
+          type: string
+        md5sum:
+          description: Driver package md5sum to ensure package is not corrupted
+          type: string
+        name:
+          description: Unique identifier key
+          type: string
+        operating_system:
+          description: Operator System supported by GPU driver build, valid values
+            are one of Linux, Windows, Others, or 0, 1, 20
+          type: string
+        storage_path:
+          description: GPU driver build storage path
+          type: string
+      type: object
+    EdgeprotoGPUDriverBuildMember:
+      properties:
+        build:
+          $ref: '#/components/schemas/EdgeprotoGPUDriverBuild'
+        ignore_state:
+          description: Ignore state will ignore any action in-progress on the GPU
+            driver
+          type: boolean
+        key:
+          $ref: '#/components/schemas/EdgeprotoGPUDriverKey'
+      type: object
+    EdgeprotoGPUDriverBuildURL:
+      properties:
+        build_url_path:
+          description: Build URL path
+          type: string
+        validity:
+          description: Build URL path validity
+          type: string
+      type: object
+    EdgeprotoGPUDriverKey:
+      properties:
+        name:
+          description: Name of the driver
+          type: string
+        organization:
+          description: Organization to which the driver belongs to
+          type: string
+      type: object
+    EdgeprotoIdleReservableClusterInsts:
+      properties:
+        idle_time:
+          description: Idle time (duration)
+          type: string
+      type: object
+    EdgeprotoInfraConfig:
+      properties:
+        external_network_name:
+          description: Infra specific external network name
+          type: string
+        flavor_name:
+          description: Infra specific flavor name
+          type: string
+      type: object
+    EdgeprotoInfraResource:
+      properties:
+        alert_threshold:
+          description: Generate alert when more than threshold percentage of resource
+            is used
+          type: integer
+        description:
+          description: Resource description
+          type: string
+        infra_max_value:
+          description: Resource infra max value
+          minimum: 0
+          type: integer
+        name:
+          description: Resource name
+          type: string
+        quota_max_value:
+          description: Resource quota max value
+          minimum: 0
+          type: integer
+        units:
+          description: Resource units
+          type: string
+        value:
+          description: Resource value
+          minimum: 0
+          type: integer
+      type: object
+    EdgeprotoInfraResources:
+      properties:
+        vms:
+          description: Virtual machine resources info
+          items:
+            $ref: '#/components/schemas/EdgeprotoVmInfo'
+          nullable: true
+          type: array
+      type: object
+    EdgeprotoInfraResourcesSnapshot:
+      properties:
+        cluster_insts:
+          description: List of clusterinsts this resources snapshot represent
+          items:
+            $ref: '#/components/schemas/EdgeprotoClusterInstRefKey'
+          nullable: true
+          type: array
+        info:
+          description: Infra Resource information
+          items:
+            $ref: '#/components/schemas/EdgeprotoInfraResource'
+          nullable: true
+          type: array
+        k8s_app_insts:
+          description: List of k8s appinsts this resources snapshot represent
+          items:
+            $ref: '#/components/schemas/EdgeprotoAppInstRefKey'
+          nullable: true
+          type: array
+        platform_vms:
+          description: Virtual machine resources info
+          items:
+            $ref: '#/components/schemas/EdgeprotoVmInfo'
+          nullable: true
+          type: array
+        vm_app_insts:
+          description: List of vm appinsts this resources snapshot represent
+          items:
+            $ref: '#/components/schemas/EdgeprotoAppInstRefKey'
+          nullable: true
+          type: array
+      type: object
+    EdgeprotoIpAddr:
+      properties:
+        externalIp:
+          description: External IP address
+          type: string
+        internalIp:
+          description: Internal IP address
+          type: string
+      type: object
+    EdgeprotoMaxReqsRateLimitSettings:
+      properties:
+        key:
+          $ref: '#/components/schemas/EdgeprotoMaxReqsRateLimitSettingsKey'
+        settings:
+          $ref: '#/components/schemas/EdgeprotoMaxReqsSettings'
+      type: object
+    EdgeprotoMaxReqsRateLimitSettingsKey:
+      properties:
+        max_reqs_settings_name:
+          description: Unique name for MaxReqsRateLimitSettings (there can be multiple
+            MaxReqsSettings per RateLimitSettingsKey)
+          type: string
+        rate_limit_key:
+          $ref: '#/components/schemas/EdgeprotoRateLimitSettingsKey'
+      type: object
+    EdgeprotoMaxReqsSettings:
+      properties:
+        interval:
+          description: Time interval
+          type: string
+        max_reqs_algorithm:
+          description: MaxReqs Rate Limit Algorithm, valid values are one of UnknownMaxReqsAlgorithm,
+            FixedWindowAlgorithm, or 0, 1
+          type: string
+        max_requests:
+          description: Maximum number of requests for the given Interval
+          type: integer
+      type: object
+    EdgeprotoNetwork:
+      properties:
+        connection_type:
+          description: Network connection type, valid values are one of Undefined,
+            ConnectToLoadBalancer, ConnectToClusterNodes, ConnectToAll, or 0, 1, 2,
+            3
+          type: string
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        key:
+          $ref: '#/components/schemas/EdgeprotoNetworkKey'
+        routes:
+          description: List of routes
+          items:
+            $ref: '#/components/schemas/EdgeprotoRoute'
+          nullable: true
+          type: array
+      type: object
+    EdgeprotoNetworkKey:
+      properties:
+        cloudlet_key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        name:
+          description: Network Name
+          type: string
+      type: object
+    EdgeprotoNode:
+      properties:
+        build_author:
+          description: Build Author
+          type: string
+        build_date:
+          description: Build Date
+          type: string
+        build_head:
+          description: Build Head Version
+          type: string
+        build_master:
+          description: Build Master Version
+          type: string
+        container_version:
+          description: Docker edge-cloud container version which node instance use
+          type: string
+        hostname:
+          description: Hostname
+          type: string
+        internal_pki:
+          description: Internal PKI Config
+          type: string
+        key:
+          $ref: '#/components/schemas/EdgeprotoNodeKey'
+        notify_id:
+          description: Id of client assigned by server (internal use only)
+          type: integer
+        properties:
+          additionalProperties:
+            type: string
+          description: Additional properties
+          type: object
+      type: object
+    EdgeprotoNodeInfo:
+      properties:
+        allocatable:
+          additionalProperties:
+            $ref: '#/components/schemas/EdgeprotoUdec64'
+          description: Maximum allocatable resources on the node (capacity - overhead)
+          type: object
+        capacity:
+          additionalProperties:
+            $ref: '#/components/schemas/EdgeprotoUdec64'
+          description: Capacity of underlying resources on the node
+          type: object
+        name:
+          description: Node name
+          type: string
+      type: object
+    EdgeprotoNodeKey:
+      properties:
+        cloudlet_key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        name:
+          description: Name or hostname of node
+          type: string
+        region:
+          description: Region the node is in
+          type: string
+        type:
+          description: Node type
+          type: string
+      type: object
+    EdgeprotoOSAZone:
+      properties:
+        name:
+          description: OpenStack availability zone name
+          type: string
+        status:
+          description: OpenStack availability zone status
+          type: string
+      type: object
+    EdgeprotoOSImage:
+      properties:
+        disk_format:
+          description: format qcow2, img, etc
+          type: string
+        name:
+          description: image name
+          type: string
+        properties:
+          description: image properties/metadata
+          type: string
+        tags:
+          description: optional tags present on image
+          type: string
+      type: object
+    EdgeprotoOperationTimeLimits:
+      properties:
+        create_app_inst_timeout:
+          description: Override default max time to create an app instance (duration)
+          type: string
+        create_cluster_inst_timeout:
+          description: Override default max time to create a cluster instance (duration)
+          type: string
+        delete_app_inst_timeout:
+          description: Override default max time to delete an app instance (duration)
+          type: string
+        delete_cluster_inst_timeout:
+          description: Override default max time to delete a cluster instance (duration)
+          type: string
+        update_app_inst_timeout:
+          description: Override default max time to update an app instance (duration)
+          type: string
+        update_cluster_inst_timeout:
+          description: Override default max time to update a cluster instance (duration)
+          type: string
+      type: object
+    EdgeprotoOperatorCode:
+      properties:
+        code:
+          description: MCC plus MNC code, or custom carrier code designation.
+          type: string
+        organization:
+          description: Operator Organization name
+          type: string
+      type: object
+    EdgeprotoOrganization:
+      properties:
+        name:
+          description: Organization name
+          type: string
+      type: object
+    EdgeprotoPlatformConfig:
+      properties:
+        access_api_addr:
+          description: controller access API address
+          type: string
+        app_dns_root:
+          description: App domain name root
+          type: string
+        cache_dir:
+          description: cache dir
+          type: string
+        chef_client_interval:
+          description: Chef client interval
+          type: string
+        chef_server_path:
+          description: Path to Chef Server
+          type: string
+        cleanup_mode:
+          description: Internal cleanup flag
+          type: boolean
+        cloudlet_vm_image_path:
+          description: Path to platform base image
+          type: string
+        commercial_certs:
+          description: Get certs from vault or generate your own for the root load
+            balancer
+          type: boolean
+        container_registry_path:
+          description: Path to Docker registry holding edge-cloud image
+          type: string
+        crm_access_private_key:
+          description: crm access private key
+          type: string
+        deployment_tag:
+          description: Deployment Tag
+          type: string
+        env_var:
+          additionalProperties:
+            type: string
+          description: Environment variables
+          type: object
+        notify_ctrl_addrs:
+          description: Address of controller notify port (can be multiple of these)
+          type: string
+        platform_tag:
+          description: Tag of edge-cloud image
+          type: string
+        region:
+          description: Region
+          type: string
+        secondary_crm_access_private_key:
+          description: secondary crm access private key
+          type: string
+        span:
+          description: Span string
+          type: string
+        test_mode:
+          description: Internal Test flag
+          type: boolean
+        thanos_recv_addr:
+          description: Thanos Receive remote write address
+          type: string
+        tls_ca_file:
+          description: TLS ca file
+          type: string
+        tls_cert_file:
+          description: TLS cert file
+          type: string
+        tls_key_file:
+          description: TLS key file
+          type: string
+        use_vault_pki:
+          description: Use Vault certs and CAs for internal TLS communication
+          type: boolean
+      type: object
+    EdgeprotoPolicyKey:
+      properties:
+        name:
+          description: Policy name
+          type: string
+        organization:
+          description: Name of the organization for the cluster that this policy will
+            apply to
+          type: string
+      type: object
+    EdgeprotoPropertyInfo:
+      properties:
+        description:
+          description: Description of the property
+          type: string
+        internal:
+          description: Is the property internal, not to be set by Operator
+          type: boolean
+        mandatory:
+          description: Is the property mandatory
+          type: boolean
+        name:
+          description: Name of the property
+          type: string
+        secret:
+          description: Is the property a secret value, will be hidden
+          type: boolean
+        value:
+          description: Default value of the property
+          type: string
+      type: object
+    EdgeprotoRateLimitSettings:
+      properties:
+        flow_settings:
+          additionalProperties:
+            $ref: '#/components/schemas/EdgeprotoFlowSettings'
+          description: 'Map of FlowSettings (key: FlowSettingsName, value: FlowSettings)'
+          type: object
+        key:
+          $ref: '#/components/schemas/EdgeprotoRateLimitSettingsKey'
+        max_reqs_settings:
+          additionalProperties:
+            $ref: '#/components/schemas/EdgeprotoMaxReqsSettings'
+          description: 'Map of MaxReqsSettings (key: MaxReqsSettingsName, value: MaxReqsSettings)'
+          type: object
+      type: object
+    EdgeprotoRateLimitSettingsKey:
+      properties:
+        api_endpoint_type:
+          description: API Endpoint type, valid values are one of UnknownApiEndpointType,
+            Dme, or 0, 1
+          type: string
+        api_name:
+          description: Name of API (eg. CreateApp or RegisterClient) (Use "Global"
+            if not a specific API)
+          type: string
+        rate_limit_target:
+          description: Target to rate limit, valid values are one of UnknownTarget,
+            AllRequests, PerIp, PerUser, or 0, 1, 2, 3
+          type: string
+      type: object
+    EdgeprotoResTagTable:
+      properties:
+        azone:
+          description: Availability zone(s) of resource if required
+          type: string
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        key:
+          $ref: '#/components/schemas/EdgeprotoResTagTableKey'
+        tags:
+          additionalProperties:
+            type: string
+          description: One or more string tags
+          type: object
+      type: object
+    EdgeprotoResTagTableKey:
+      properties:
+        name:
+          description: Resource Table Name
+          type: string
+        organization:
+          description: Operator organization of the cloudlet site.
+          type: string
+      type: object
+    EdgeprotoResourceQuota:
+      properties:
+        alert_threshold:
+          description: Generate alert when more than threshold percentage of resource
+            is used
+          type: integer
+        name:
+          description: Resource name on which to set quota
+          type: string
+        value:
+          description: Quota value of the resource
+          minimum: 0
+          type: integer
+      type: object
+    EdgeprotoResult:
+      properties:
+        code:
+          description: Error code, 0 indicates success, non-zero indicates failure
+            (not implemented)
+          type: integer
+        message:
+          description: Message, may be success or failure message
+          type: string
+      type: object
+    EdgeprotoRoute:
+      properties:
+        destination_cidr:
+          description: Destination CIDR
+          type: string
+        next_hop_ip:
+          description: Next hop IP
+          type: string
+      type: object
+    EdgeprotoRunCmd:
+      properties:
+        cloudlet_mgmt_node:
+          $ref: '#/components/schemas/EdgeprotoCloudletMgmtNode'
+        command:
+          description: Command or Shell
+          type: string
+      type: object
+    EdgeprotoRunVMConsole:
+      properties:
+        url:
+          description: VM Console URL
+          type: string
+      type: object
+    EdgeprotoSecurityRule:
+      properties:
+        port_range_max:
+          description: TCP or UDP port range end
+          minimum: 0
+          type: integer
+        port_range_min:
+          description: TCP or UDP port range start
+          minimum: 0
+          type: integer
+        protocol:
+          description: TCP, UDP, ICMP
+          type: string
+        remote_cidr:
+          description: Remote CIDR X.X.X.X/X
+          type: string
+      type: object
+    EdgeprotoServerlessConfig:
+      properties:
+        min_replicas:
+          description: Minimum number of replicas when serverless
+          minimum: 0
+          type: integer
+        ram:
+          description: RAM allocation in megabytes per container when serverless
+          minimum: 0
+          type: integer
+        vcpus:
+          description: Virtual CPUs allocation per container when serverless, may
+            be decimal in increments of 0.001
+          type: string
+      type: object
+    EdgeprotoSettings:
+      properties:
+        alert_policy_min_trigger_time:
+          description: Minimmum trigger time for alert policies
+          type: string
+        appinst_client_cleanup_interval:
+          description: AppInstClient cleanup thread run interval
+          type: string
+        auto_deploy_interval_sec:
+          description: Auto Provisioning Stats push and analysis interval (seconds)
+          type: number
+        auto_deploy_max_intervals:
+          description: Auto Provisioning Policy max allowed intervals
+          minimum: 0
+          type: integer
+        auto_deploy_offset_sec:
+          description: Auto Provisioning analysis offset from interval (seconds)
+          type: number
+        chef_client_interval:
+          description: Default chef client interval (duration)
+          type: string
+        cleanup_reservable_auto_cluster_idletime:
+          description: Idle reservable ClusterInst clean up time
+          type: string
+        cloudlet_maintenance_timeout:
+          description: Default Cloudlet Maintenance timeout (used twice for AutoProv
+            and Cloudlet)
+          type: string
+        cluster_auto_scale_averaging_duration_sec:
+          description: Cluster auto scale averaging duration for stats to avoid spikes
+            (seconds), avoid setting below 30s or it will not capture any measurements
+            to average
+          type: integer
+        cluster_auto_scale_retry_delay:
+          description: Cluster auto scale retry delay if scaling failed
+          type: string
+        create_app_inst_timeout:
+          description: Create AppInst timeout (duration)
+          type: string
+        create_cloudlet_timeout:
+          description: Create Cloudlet timeout (duration)
+          type: string
+        create_cluster_inst_timeout:
+          description: Create ClusterInst timeout (duration)
+          type: string
+        delete_app_inst_timeout:
+          description: Delete AppInst timeout (duration)
+          type: string
+        delete_cluster_inst_timeout:
+          description: Delete ClusterInst timeout (duration)
+          type: string
+        disable_rate_limit:
+          description: Disable rate limiting for APIs (default is false)
+          type: boolean
+        dme_api_metrics_collection_interval:
+          description: Metrics collection interval for DME API counts (duration)
+          type: string
+        edge_events_metrics_collection_interval:
+          description: Collection interval for edgeevents metrics (latency, device,
+            and custom)
+          type: string
+        edge_events_metrics_continuous_queries_collection_intervals:
+          description: List of collection intervals for Continuous Queries for EdgeEvents
+            metrics
+          items:
+            $ref: '#/components/schemas/EdgeprotoCollectionInterval'
+          type: array
+        influx_db_cloudlet_usage_metrics_retention:
+          description: Default influxDB cloudlet usage metrics retention policy (duration)
+          type: string
+        influx_db_downsampled_metrics_retention:
+          description: Default retention policy for downsampled influx db (duration)
+          type: string
+        influx_db_edge_events_metrics_retention:
+          description: Default retention policy for edgeevents metrics influx db (duration)
+          type: string
+        influx_db_metrics_retention:
+          description: Default influxDB metrics retention policy (duration)
+          type: string
+        location_tile_side_length_km:
+          description: Length of location tiles side for latency metrics (km)
+          type: integer
+        master_node_flavor:
+          description: Default flavor for k8s master VM and > 0  workers
+          type: string
+        max_tracked_dme_clients:
+          description: Max DME clients to be tracked at the same time.
+          type: integer
+        platform_ha_instance_active_expire_time:
+          description: Platform HA instance active time
+          type: string
+        platform_ha_instance_poll_interval:
+          description: Platform HA instance poll interval
+          type: string
+        rate_limit_max_tracked_ips:
+          description: Maximum number of IPs to track for rate limiting
+          type: integer
+        resource_snapshot_thread_interval:
+          description: ResourceSnapshot Refresh thread run interval
+          type: string
+        shepherd_alert_evaluation_interval:
+          description: Shepherd alert evaluation interval for k8s and docker appInstances
+            (duration)
+          type: string
+        shepherd_health_check_interval:
+          description: Health Checking probing frequency (duration)
+          type: string
+        shepherd_health_check_retries:
+          description: Number of times Shepherd Health Check fails before we mark
+            appInst down
+          type: integer
+        shepherd_metrics_collection_interval:
+          description: Shepherd metrics collection interval for k8s and docker appInstances
+            (duration)
+          type: string
+        shepherd_metrics_scrape_interval:
+          description: Shepherd metrics scraping interval (how often metrics are pulled
+            by prometheus, vs pushed to Controller by Shepherd collection)
+          type: string
+        update_app_inst_timeout:
+          description: Update AppInst timeout (duration)
+          type: string
+        update_cloudlet_timeout:
+          description: Update Cloudlet timeout (duration)
+          type: string
+        update_cluster_inst_timeout:
+          description: Update ClusterInst timeout (duration)
+          type: string
+        update_trust_policy_timeout:
+          description: Update Trust Policy timeout (duration)
+          type: string
+        update_vm_pool_timeout:
+          description: Update VM pool timeout (duration)
+          type: string
+      type: object
+    EdgeprotoShowLog:
+      properties:
+        follow:
+          description: Stream data
+          type: boolean
+        since:
+          description: Show logs since either a duration ago (5s, 2m, 3h) or a timestamp
+            (RFC3339)
+          type: string
+        tail:
+          description: Show only a recent number of lines
+          type: integer
+        timestamps:
+          description: Show timestamps
+          type: boolean
+      type: object
+    EdgeprotoStatusInfo:
+      properties:
+        max_tasks:
+          description: Max tasks
+          minimum: 0
+          type: integer
+        msg_count:
+          description: Message count
+          minimum: 0
+          type: integer
+        msgs:
+          description: Messages
+          items:
+            type: string
+          type: array
+        step_name:
+          description: Step name
+          type: string
+        task_name:
+          description: Task name
+          type: string
+        task_number:
+          description: Task number
+          minimum: 0
+          type: integer
+      type: object
+    EdgeprotoTimeRange:
+      properties:
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    EdgeprotoTrustPolicy:
+      properties:
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        key:
+          $ref: '#/components/schemas/EdgeprotoPolicyKey'
+        outbound_security_rules:
+          description: List of outbound security rules for whitelisting traffic
+          items:
+            $ref: '#/components/schemas/EdgeprotoSecurityRule'
+          nullable: true
+          type: array
+      type: object
+    EdgeprotoTrustPolicyException:
+      properties:
+        key:
+          $ref: '#/components/schemas/EdgeprotoTrustPolicyExceptionKey'
+        outbound_security_rules:
+          description: List of outbound security rules for whitelisting traffic
+          items:
+            $ref: '#/components/schemas/EdgeprotoSecurityRule'
+          nullable: true
+          type: array
+        state:
+          description: State of the exception within the approval process, valid values
+            are one of Unknown, ApprovalRequested, Active, Rejected, or 0, 1, 2, 3
+          type: string
+      type: object
+    EdgeprotoTrustPolicyExceptionKey:
+      properties:
+        app_key:
+          $ref: '#/components/schemas/EdgeprotoAppKey'
+        cloudlet_pool_key:
+          $ref: '#/components/schemas/EdgeprotoCloudletPoolKey'
+        name:
+          description: TrustPolicyExceptionKey name
+          type: string
+      type: object
+    EdgeprotoUdec64:
+      properties:
+        nanos:
+          description: Decimal value in nanos
+          minimum: 0
+          type: integer
+        whole:
+          description: Whole number value
+          minimum: 0
+          type: integer
+      type: object
+    EdgeprotoVM:
+      properties:
+        flavor:
+          $ref: '#/components/schemas/EdgeprotoFlavorInfo'
+        group_name:
+          description: VM Group Name
+          type: string
+        internal_name:
+          description: VM Internal Name
+          type: string
+        name:
+          description: VM Name
+          type: string
+        net_info:
+          $ref: '#/components/schemas/EdgeprotoVMNetInfo'
+        state:
+          description: VM State, valid values are one of Free, InProgress, InUse,
+            Add, Remove, Update, ForceFree, or 0, 1, 2, 3, 4, 5, 6
+          type: string
+        updated_at:
+          $ref: '#/components/schemas/TypesTimestamp'
+      type: object
+    EdgeprotoVMNetInfo:
+      properties:
+        external_ip:
+          description: External IP
+          type: string
+        internal_ip:
+          description: Internal IP
+          type: string
+      type: object
+    EdgeprotoVMPool:
+      properties:
+        crm_override:
+          description: Override actions to CRM, valid values are one of NoOverride,
+            IgnoreCrmErrors, IgnoreCrm, IgnoreTransientState, IgnoreCrmAndTransientState,
+            or 0, 1, 2, 3, 4
+          type: string
+        delete_prepare:
+          description: Preparing to be deleted
+          type: boolean
+        errors:
+          description: Any errors trying to add/remove VM to/from VM Pool
+          items:
+            type: string
+          type: array
+        key:
+          $ref: '#/components/schemas/EdgeprotoVMPoolKey'
+        state:
+          description: Current state of the VM pool, valid values are one of TrackedStateUnknown,
+            NotPresent, CreateRequested, Creating, CreateError, Ready, UpdateRequested,
+            Updating, UpdateError, DeleteRequested, Deleting, DeleteError, DeletePrepare,
+            CrmInitok, CreatingDependencies, DeleteDone, or 0, 1, 2, 3, 4, 5, 6, 7,
+            8, 9, 10, 11, 12, 13, 14, 15
+          type: string
+        vms:
+          description: list of VMs to be part of VM pool
+          items:
+            $ref: '#/components/schemas/EdgeprotoVM'
+          nullable: true
+          type: array
+      type: object
+    EdgeprotoVMPoolKey:
+      properties:
+        name:
+          description: Name of the vmpool
+          type: string
+        organization:
+          description: Organization of the vmpool
+          type: string
+      type: object
+    EdgeprotoVMPoolMember:
+      properties:
+        crm_override:
+          description: Override actions to CRM, valid values are one of NoOverride,
+            IgnoreCrmErrors, IgnoreCrm, IgnoreTransientState, IgnoreCrmAndTransientState,
+            or 0, 1, 2, 3, 4
+          type: string
+        key:
+          $ref: '#/components/schemas/EdgeprotoVMPoolKey'
+        vm:
+          $ref: '#/components/schemas/EdgeprotoVM'
+      type: object
+    EdgeprotoVirtualClusterInstKey:
+      properties:
+        cloudlet_key:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        cluster_key:
+          $ref: '#/components/schemas/EdgeprotoClusterKey'
+        organization:
+          description: Name of Developer organization that this cluster belongs to
+          type: string
+      type: object
+    EdgeprotoVmInfo:
+      properties:
+        containers:
+          description: Information about containers running in the VM
+          items:
+            $ref: '#/components/schemas/EdgeprotoContainerInfo'
+          type: array
+        infraFlavor:
+          description: Flavor allocated within the cloudlet infrastructure, distinct
+            from the control plane flavor
+          type: string
+        ipaddresses:
+          description: IP addresses allocated to the VM
+          items:
+            $ref: '#/components/schemas/EdgeprotoIpAddr'
+          nullable: true
+          type: array
+        name:
+          description: Virtual machine name
+          type: string
+        status:
+          description: Runtime status of the VM
+          type: string
+        type:
+          description: Type can be platformvm, platform-cluster-master, platform-cluster-primary-node,
+            platform-cluster-secondary-node, sharedrootlb, dedicatedrootlb, cluster-master,
+            cluster-k8s-node, cluster-docker-node, appvm
+          type: string
+      type: object
+    NodeAggrVal:
+      properties:
+        count:
+          description: Count of number of documents associated with key
+          type: integer
+        key:
+          description: Key
+          type: string
+      type: object
+    NodeEventData:
+      properties:
+        error:
+          description: Error if event is logging a failure
+          type: string
+        mtags:
+          additionalProperties:
+            type: string
+          description: Tags associated with event
+          type: object
+        name:
+          description: Name of event
+          type: string
+        org:
+          description: Organizations that scan see event
+          items:
+            type: string
+          nullable: true
+          type: array
+        region:
+          description: Region in which event happened
+          type: string
+        tags:
+          description: Tags associated with event
+          items:
+            $ref: '#/components/schemas/NodeEventTag'
+          type: array
+        timestamp:
+          description: Timestamp of event
+          format: date-time
+          type: string
+        type:
+          description: Type of event, audit or event
+          type: string
+      type: object
+    NodeEventMatch:
+      properties:
+        error:
+          description: Error substring to match
+          type: string
+        failed:
+          description: Failure status on event to match
+          type: boolean
+        names:
+          description: Names of events to match
+          items:
+            type: string
+          nullable: true
+          type: array
+        orgs:
+          description: Organizations on events to match
+          items:
+            type: string
+          nullable: true
+          type: array
+        regions:
+          description: Regions on events to match
+          items:
+            type: string
+          type: array
+        tags:
+          additionalProperties:
+            type: string
+          description: Tags on events to match
+          nullable: true
+          type: object
+        types:
+          description: Types of events to match
+          items:
+            type: string
+          nullable: true
+          type: array
+      type: object
+    NodeEventSearch:
+      properties:
+        allowedorgs:
+          description: Organizations allowed to access the event
+          items:
+            type: string
+          nullable: true
+          type: array
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        from:
+          description: Start offset if paging through results
+          type: integer
+        limit:
+          description: Display the last X events
+          type: integer
+        match:
+          $ref: '#/components/schemas/NodeEventMatch'
+        notmatch:
+          $ref: '#/components/schemas/NodeEventMatch'
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    NodeEventTag:
+      properties:
+        key:
+          description: Event tag key
+          type: string
+        value:
+          description: Event tag value
+          type: string
+      type: object
+    NodeEventTerms:
+      properties:
+        names:
+          description: Names of events
+          items:
+            $ref: '#/components/schemas/NodeAggrVal'
+          type: array
+        orgs:
+          description: Organizations on events
+          items:
+            $ref: '#/components/schemas/NodeAggrVal'
+          type: array
+        regions:
+          description: Regions on events
+          items:
+            $ref: '#/components/schemas/NodeAggrVal'
+          type: array
+        tagkeys:
+          description: Tag keys on events
+          items:
+            $ref: '#/components/schemas/NodeAggrVal'
+          type: array
+        types:
+          description: Types of events
+          items:
+            $ref: '#/components/schemas/NodeAggrVal'
+          type: array
+      type: object
+    NodeSpanLogOut:
+      properties:
+        keyvalues:
+          additionalProperties: {}
+          nullable: true
+          type: object
+        lineno:
+          type: string
+        msg:
+          type: string
+        timestamp:
+          format: date-time
+          type: string
+      type: object
+    NodeSpanMatch:
+      properties:
+        hostnames:
+          items:
+            type: string
+          nullable: true
+          type: array
+        logkeyvalues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+        logmsgs:
+          items:
+            type: string
+          nullable: true
+          type: array
+        logvalues:
+          items:
+            type: string
+          nullable: true
+          type: array
+        operations:
+          items:
+            type: string
+          nullable: true
+          type: array
+        services:
+          items:
+            type: string
+          nullable: true
+          type: array
+        spanids:
+          items:
+            type: string
+          nullable: true
+          type: array
+        tagkeyvalues:
+          additionalProperties:
+            type: string
+          nullable: true
+          type: object
+        tagvalues:
+          items:
+            type: string
+          nullable: true
+          type: array
+        traceids:
+          items:
+            type: string
+          nullable: true
+          type: array
+      type: object
+    NodeSpanOutCondensed:
+      properties:
+        duration:
+          type: string
+        hostname:
+          type: string
+        logs:
+          items:
+            $ref: '#/components/schemas/NodeSpanLogOut'
+          type: array
+        operation:
+          type: string
+        service:
+          type: string
+        spanid:
+          type: string
+        starttime:
+          format: date-time
+          type: string
+        tags:
+          additionalProperties: {}
+          type: object
+        traceid:
+          type: string
+      type: object
+    NodeSpanSearch:
+      properties:
+        TimeRange:
+          $ref: '#/components/schemas/EdgeprotoTimeRange'
+        from:
+          type: integer
+        limit:
+          type: integer
+        match:
+          $ref: '#/components/schemas/NodeSpanMatch'
+        notmatch:
+          $ref: '#/components/schemas/NodeSpanMatch'
+        searchbyrelevance:
+          type: boolean
+      type: object
+    NodeSpanTerms:
+      properties:
+        hostnames:
+          items:
+            $ref: '#/components/schemas/NodeAggrVal'
+          nullable: true
+          type: array
+        msgs:
+          items:
+            $ref: '#/components/schemas/NodeAggrVal'
+          nullable: true
+          type: array
+        operations:
+          items:
+            $ref: '#/components/schemas/NodeAggrVal'
+          nullable: true
+          type: array
+        services:
+          items:
+            $ref: '#/components/schemas/NodeAggrVal'
+          nullable: true
+          type: array
+        tags:
+          items:
+            $ref: '#/components/schemas/NodeAggrVal'
+          nullable: true
+          type: array
+      type: object
+    OrmapiAccountInfo:
+      properties:
+        AccountId:
+          description: Account ID given by the billing platform
+          type: string
+        OrgName:
+          description: Billing Organization name to commit
+          type: string
+        ParentId:
+          description: Parent ID
+          type: string
+        SubscriptionId:
+          description: Subscription ID given by the billing platform
+          type: string
+        Type:
+          description: Type, either parent, child, or self
+          type: string
+      type: object
+    OrmapiAlertReceiver:
+      properties:
+        AppInst:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        Cloudlet:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        Email:
+          description: Custom receiving email
+          type: string
+        Name:
+          description: Receiver Name
+          type: string
+        PagerDutyApiVersion:
+          description: PagerDuty API version
+          type: string
+        PagerDutyIntegrationKey:
+          description: PagerDuty integration key
+          type: string
+        Region:
+          description: Region for the alert receiver
+          type: string
+        Severity:
+          description: Alert severity filter
+          type: string
+        SlackChannel:
+          description: Custom slack channel
+          type: string
+        SlackWebhook:
+          description: Custom slack webhook
+          type: string
+        Type:
+          description: Receiver type. Eg. email, slack, pagerduty
+          type: string
+        User:
+          description: User that created this receiver
+          type: string
+      type: object
+    OrmapiAllMetrics:
+      properties:
+        data:
+          description: Metrics data
+          items:
+            $ref: '#/components/schemas/OrmapiMetricData'
+          nullable: true
+          type: array
+      type: object
+    OrmapiBillingOrganization:
+      properties:
+        Address:
+          description: Organization address
+          type: string
+        Address2:
+          description: Organization address2
+          type: string
+        Children:
+          description: Children belonging to this BillingOrganization
+          type: string
+        City:
+          description: Organization city
+          type: string
+        Country:
+          description: Organization country
+          type: string
+        CreatedAt:
+          description: Time created
+          format: date-time
+          readOnly: true
+          type: string
+        DeleteInProgress:
+          description: Delete of this BillingOrganization is in progress
+          readOnly: true
+          type: boolean
+        Email:
+          description: Organization email
+          type: string
+        FirstName:
+          description: Billing info first name
+          type: string
+        LastName:
+          description: Billing info last name
+          type: string
+        Name:
+          description: BillingOrganization name. Can only contain letters, digits,
+            underscore, period, hyphen. It cannot have leading or trailing spaces
+            or period. It cannot start with hyphen
+          type: string
+        Phone:
+          description: Organization phone number
+          type: string
+        PostalCode:
+          description: Organization postal code
+          type: string
+        State:
+          description: Organization state
+          type: string
+        Type:
+          description: 'Organization type: "parent" or "self"'
+          type: string
+        UpdatedAt:
+          description: Time last updated
+          format: date-time
+          readOnly: true
+          type: string
+      type: object
+    OrmapiConfig:
+      properties:
+        AdminPasswordMinCrackTimeSec:
+          description: Admin accounts min password crack time seconds (a measure of
+            strength)
+          type: number
+        ApiKeyLoginTokenValidDuration:
+          description: API key login token valid duration (in format 2h30m10s, default
+            4h)
+          type: string
+        BillingEnable:
+          description: Toggle for enabling billing (primarily for testing purposes)
+          type: boolean
+        DisableRateLimit:
+          description: Toggle to enable and disable MC API rate limiting
+          type: boolean
+        FailedLoginLockoutThreshold1:
+          description: Failed login lockout threshold 1, after this count, lockout
+            time 1 is enabled (default 3)
+          type: integer
+        FailedLoginLockoutThreshold2:
+          description: Failed login lockout threshold 2, after this count, lockout
+            time 2 is enabled (default 10)
+          type: integer
+        FailedLoginLockoutTimeSec1:
+          description: Number of seconds to lock account from logging in after threshold
+            1 is hit (default 60)
+          type: integer
+        FailedLoginLockoutTimeSec2:
+          description: Number of seconds to lock account from logging in after threshold
+            2 is hit (default 300)
+          type: integer
+        LockNewAccounts:
+          description: Lock new accounts (must be unlocked by admin)
+          type: boolean
+        MaxMetricsDataPoints:
+          description: InfluxDB max number of data points returned
+          type: integer
+        NotifyEmailAddress:
+          description: Email to notify when locked account is created, defaults to
+            SupportEmail
+          type: string
+        PasswordMinCrackTimeSec:
+          description: User accounts min password crack time seconds (a measure of
+            strength)
+          type: number
+        RateLimitMaxTrackedIps:
+          description: Maximum number of IPs tracked per API group for rate limiting
+            at MC
+          type: integer
+        RateLimitMaxTrackedUsers:
+          description: Maximum number of users tracked per API group for rate limiting
+            at MC
+          type: integer
+        SkipVerifyEmail:
+          description: Skip email verification for new accounts (testing only)
+          type: boolean
+        SlackIconURL:
+          description: Slack icon URL used for alert manager slack receivers
+          type: string
+        SupportEmail:
+          description: Support email address shown to users, i.e. support@edgecloud.net
+          type: string
+        UserApiKeyCreateLimit:
+          description: Max number of API keys a user can create
+          type: integer
+        UserLoginTokenValidDuration:
+          description: User login token valid duration (in format 2h30m10s, default
+            24h)
+          type: string
+        WebsocketTokenValidDuration:
+          description: Websocket auth token valid duration (in format 2h30m10s, default
+            2m)
+          type: string
+      type: object
+    OrmapiController:
+      properties:
+        Address:
+          description: Controller API address or URL
+          type: string
+        CreatedAt:
+          description: Time created
+          format: date-time
+          readOnly: true
+          type: string
+        DnsRegion:
+          description: Unique DNS label for the region
+          readOnly: true
+          type: string
+        InfluxDB:
+          description: InfluxDB address
+          type: string
+        NotifyAddr:
+          description: Controller notify address or URL
+          type: string
+        Region:
+          description: Controller region name
+          type: string
+        ThanosMetrics:
+          description: Thanos Query URL
+          type: string
+        UpdatedAt:
+          description: Time last updated
+          format: date-time
+          readOnly: true
+          type: string
+      type: object
+    OrmapiCreateUser:
+      properties:
+        CreatedAt:
+          description: Time created
+          format: date-time
+          readOnly: true
+          type: string
+        Email:
+          description: User email
+          type: string
+        EmailVerified:
+          description: Email address has been verified
+          readOnly: true
+          type: boolean
+        EnableTOTP:
+          description: Enable or disable temporary one-time passwords for the account
+          type: boolean
+        FailedLogins:
+          description: Number of failed login attempts since last successful login
+          type: integer
+        FamilyName:
+          description: Family Name
+          type: string
+        GivenName:
+          description: Given Name
+          type: string
+        LastFailedLogin:
+          description: Last failed login time
+          format: date-time
+          readOnly: true
+          type: string
+        LastLogin:
+          description: Last successful login time
+          format: date-time
+          readOnly: true
+          type: string
+        Locked:
+          description: Account is locked
+          readOnly: true
+          type: boolean
+        Metadata:
+          description: Metadata
+          type: string
+        Name:
+          description: User name. Can only contain letters, digits, underscore, period,
+            hyphen. It cannot have leading or trailing spaces or period. It cannot
+            start with hyphen
+          type: string
+        Nickname:
+          description: Nick Name
+          type: string
+        PassCrackTimeSec:
+          description: Password strength in terms of brute-force cracking time
+          readOnly: true
+          type: number
+        Picture:
+          description: Picture (currently not used)
+          type: string
+        UpdatedAt:
+          description: Time last updated
+          format: date-time
+          readOnly: true
+          type: string
+        verify:
+          $ref: '#/components/schemas/OrmapiEmailRequest'
+      type: object
+    OrmapiCreateUserApiKey:
+      properties:
+        ApiKey:
+          description: API key
+          type: string
+        CreatedAt:
+          description: Time created
+          format: date-time
+          readOnly: true
+          type: string
+        Description:
+          description: Description of the purpose of this API key
+          type: string
+        Id:
+          description: API key ID used as an identifier for API keys
+          readOnly: true
+          type: string
+        Org:
+          description: Org to which API key has permissions to access its objects
+          type: string
+        permissions:
+          description: List of API key permissions
+          items:
+            $ref: '#/components/schemas/OrmapiRolePerm'
+          nullable: true
+          type: array
+      type: object
+    OrmapiDownloadReport:
+      properties:
+        Filename:
+          description: Name of the report file to be downloaded
+          type: string
+        Org:
+          description: Organization name
+          type: string
+        Reporter:
+          description: Reporter name
+          type: string
+      type: object
+    OrmapiEmailRequest:
+      properties:
+        email:
+          description: User's email address
+          readOnly: true
+          type: string
+      type: object
+    OrmapiFederatedPartnerZone:
+      properties:
+        Registered:
+          description: Zone registered by self federator
+          readOnly: true
+          type: boolean
+        city:
+          description: Comma seperated list of cities under this zone
+          type: string
+        cloudlets:
+          $ref: '#/components/schemas/PqStringArray'
+        countrycode:
+          description: ISO 3166-1 Alpha-2 code for the country where operator platform
+            is located
+          type: string
+        federationname:
+          description: Name of the Federation
+          type: string
+        geolocation:
+          description: GPS co-ordinates associated with the zone (in decimal format)
+          type: string
+        locality:
+          description: Type of locality eg rural, urban etc.
+          type: string
+        operatorid:
+          description: Globally unique string to identify an operator platform
+          type: string
+        region:
+          description: Region in which cloudlets reside
+          type: string
+        revision:
+          description: Revision ID to track object changes. We use jaeger traceID
+            for easy debugging but this can differ with what partner federator uses
+          readOnly: true
+          type: string
+        selfoperatorid:
+          description: Self operator ID
+          type: string
+        state:
+          description: Comma seperated list of states under this zone
+          type: string
+        zoneid:
+          description: Globally unique string used to authenticate operations over
+            federation interface
+          type: string
+      type: object
+    OrmapiFederatedSelfZone:
+      properties:
+        Registered:
+          description: Zone registered by partner federator
+          readOnly: true
+          type: boolean
+        federationname:
+          description: Name of the Federation
+          type: string
+        revision:
+          description: Revision ID to track object changes. We use jaeger traceID
+            for easy debugging but this can differ with what partner federator uses
+          readOnly: true
+          type: string
+        selfoperatorid:
+          description: Self operator ID
+          type: string
+        zoneid:
+          description: Globally unique identifier of the federator zone
+          type: string
+      type: object
+    OrmapiFederatedZoneRegRequest:
+      properties:
+        federationname:
+          description: Name of the Federation
+          type: string
+        selfoperatorid:
+          description: Self operator ID
+          type: string
+        zones:
+          description: Partner federator zones to be registered/deregistered
+          items:
+            type: string
+          nullable: true
+          type: array
+      type: object
+    OrmapiFederation:
+      properties:
+        PartnerRoleAccessToSelfZones:
+          description: Partner is allowed access to self federator zones as part of
+            federation
+          readOnly: true
+          type: boolean
+        PartnerRoleShareZonesWithSelf:
+          description: Partner shares its zones with self federator as part of federation
+          readOnly: true
+          type: boolean
+        apikey:
+          description: API Key used for authentication (stored in secure storage)
+          type: string
+        countrycode:
+          description: ISO 3166-1 Alpha-2 code for the country where operator platform
+            is located
+          type: string
+        federationaddr:
+          description: Federation access point address
+          type: string
+        federationid:
+          description: Globally unique string used to indentify a federation with
+            partner federation
+          type: string
+        locatorendpoint:
+          description: IP and Port of discovery service URL of operator platform
+          type: string
+        mcc:
+          description: Mobile country code of operator sending the request
+          type: string
+        mnc:
+          $ref: '#/components/schemas/PqStringArray'
+        name:
+          description: Name to uniquely identify a federation
+          type: string
+        operatorid:
+          description: Globally unique string to identify an operator platform
+          type: string
+        region:
+          description: Region to which this federator is associated with
+          type: string
+        revision:
+          description: Revision ID to track object changes. We use jaeger traceID
+            for easy debugging but this can differ with what partner federator uses
+          readOnly: true
+          type: string
+        selffederationid:
+          description: Self federation ID
+          type: string
+        selfoperatorid:
+          description: Self operator ID
+          type: string
+      type: object
+    OrmapiFederator:
+      properties:
+        apikey:
+          description: API Key used for authentication (stored in secure storage)
+          type: string
+        countrycode:
+          description: ISO 3166-1 Alpha-2 code for the country where operator platform
+            is located
+          type: string
+        federationaddr:
+          description: Federation access point address
+          type: string
+        federationid:
+          description: Globally unique string used to indentify a federation with
+            partner federation
+          type: string
+        locatorendpoint:
+          description: IP and Port of discovery service URL of operator platform
+          type: string
+        mcc:
+          description: Mobile country code of operator sending the request
+          type: string
+        mnc:
+          $ref: '#/components/schemas/PqStringArray'
+        operatorid:
+          description: Globally unique string to identify an operator platform
+          type: string
+        region:
+          description: Region to which this federator is associated with
+          type: string
+        revision:
+          description: Revision ID to track object changes. We use jaeger traceID
+            for easy debugging but this can differ with what partner federator uses
+          readOnly: true
+          type: string
+      type: object
+    OrmapiFederatorZone:
+      properties:
+        city:
+          description: Comma seperated list of cities under this zone
+          type: string
+        cloudlets:
+          $ref: '#/components/schemas/PqStringArray'
+        countrycode:
+          description: ISO 3166-1 Alpha-2 code for the country where operator platform
+            is located
+          type: string
+        geolocation:
+          description: GPS co-ordinates associated with the zone (in decimal format)
+          type: string
+        locality:
+          description: Type of locality eg rural, urban etc.
+          type: string
+        operatorid:
+          description: Globally unique string to identify an operator platform
+          type: string
+        region:
+          description: Region in which cloudlets reside
+          type: string
+        revision:
+          description: Revision ID to track object changes. We use jaeger traceID
+            for easy debugging but this can differ with what partner federator uses
+          readOnly: true
+          type: string
+        state:
+          description: Comma seperated list of states under this zone
+          type: string
+        zoneid:
+          description: Globally unique string used to authenticate operations over
+            federation interface
+          type: string
+      type: object
+    OrmapiGenerateReport:
+      properties:
+        EndTime:
+          description: Absolute time (in RFC3339 format with intended timezone) to
+            end report capture
+          format: date-time
+          type: string
+        Org:
+          description: Organization name
+          type: string
+        Region:
+          description: Region name (for internal use only)
+          readOnly: true
+          type: string
+        StartTime:
+          description: Absolute time (in RFC3339 format with intended timezone) to
+            start report capture
+          format: date-time
+          type: string
+        Timezone:
+          description: Timezone in which to show the reports, defaults to UTC
+          type: string
+      type: object
+    OrmapiInvoiceRequest:
+      properties:
+        EndDate:
+          description: Date filter for invoice selection, YYYY-MM-DD format
+          type: string
+        Name:
+          description: Billing Organization name to retrieve invoices for
+          type: string
+        StartDate:
+          description: Date filter for invoice selection, YYYY-MM-DD format
+          type: string
+      type: object
+    OrmapiMcRateLimitFlowSettings:
+      properties:
+        ApiName:
+          description: Name of API Path (eg. /api/v1/usercreate)
+          type: string
+        BurstSize:
+          description: Number of requests allowed at once
+          type: integer
+        FlowAlgorithm:
+          description: Flow Algorithm (TokenBucketAlgorithm or LeakyBucketAlgorithm),
+            valid values are one of UnknownFlowAlgorithm, TokenBucketAlgorithm, LeakyBucketAlgorithm,
+            or 0, 1, 2
+          type: string
+        FlowSettingsName:
+          description: Unique name for FlowSettings
+          type: string
+        RateLimitTarget:
+          description: RateLimitTarget (AllRequests, PerIp, or PerUser), valid values
+            are one of UnknownTarget, AllRequests, PerIp, PerUser, or 0, 1, 2, 3
+          type: string
+        ReqsPerSecond:
+          description: Number of requests per second
+          type: number
+      type: object
+    OrmapiMcRateLimitMaxReqsSettings:
+      properties:
+        ApiName:
+          description: Name of API Path (eg. /api/v1/usercreate)
+          type: string
+        Interval:
+          description: Time interval
+          type: string
+        MaxReqsAlgorithm:
+          description: MaxReqs Algorithm (FixedWindowAlgorithm), valid values are
+            one of UnknownMaxReqsAlgorithm, FixedWindowAlgorithm, or 0, 1
+          type: string
+        MaxReqsSettingsName:
+          description: Unique name for MaxReqsSettings
+          type: string
+        MaxRequests:
+          description: Maximum number of requests for the specified interval
+          type: integer
+        RateLimitTarget:
+          description: RateLimitTarget (AllRequests, PerIp, or PerUser), valid values
+            are one of UnknownTarget, AllRequests, PerIp, PerUser, or 0, 1, 2, 3
+          type: string
+      type: object
+    OrmapiMcRateLimitSettings:
+      properties:
+        ApiName:
+          description: Name of API Path (eg. /api/v1/usercreate)
+          type: string
+        FlowSettings:
+          additionalProperties:
+            $ref: '#/components/schemas/EdgeprotoFlowSettings'
+          description: Map of Flow Settings name to FlowSettings
+          nullable: true
+          type: object
+        MaxReqsSettings:
+          additionalProperties:
+            $ref: '#/components/schemas/EdgeprotoMaxReqsSettings'
+          description: Map of MaxReqs Settings name to MaxReqsSettings
+          nullable: true
+          type: object
+        RateLimitTarget:
+          description: RateLimitTarget (AllRequests, PerIp, or PerUser), valid values
+            are one of UnknownTarget, AllRequests, PerIp, PerUser, or 0, 1, 2, 3
+          type: string
+      type: object
+    OrmapiMetricData:
+      properties:
+        Series:
+          description: Series data
+          items:
+            $ref: '#/components/schemas/OrmapiMetricSeries'
+          nullable: true
+          type: array
+      type: object
+    OrmapiMetricSeries:
+      properties:
+        columns:
+          description: Column names
+          items:
+            type: string
+          nullable: true
+          type: array
+        name:
+          description: Series name
+          type: string
+        tags:
+          additionalProperties:
+            type: string
+          description: Tags
+          nullable: true
+          type: object
+        values:
+          description: 2D Array of column values by time
+          items:
+            items: {}
+            type: array
+          nullable: true
+          type: array
+      type: object
+    OrmapiNewPassword:
+      properties:
+        currentpassword:
+          description: User's current password
+          type: string
+        password:
+          description: User's new password
+          type: string
+      type: object
+    OrmapiOrgCloudlet:
+      properties:
+        org:
+          description: Org that has permissions for cloudlets
+          type: string
+        region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiOrgCloudletPool:
+      properties:
+        CloudletPool:
+          description: Operator's CloudletPool name
+          type: string
+        CloudletPoolOrg:
+          description: Operator's Organization
+          type: string
+        Decision:
+          description: Decision is to either accept or reject an invitation
+          type: string
+        Org:
+          description: Developer Organization
+          type: string
+        Region:
+          description: Region
+          type: string
+        Type:
+          description: Type is an internal-only field which is either invitation or
+            response
+          type: string
+      type: object
+    OrmapiOrganization:
+      properties:
+        Address:
+          description: Organization address
+          type: string
+        CreatedAt:
+          description: Time created
+          format: date-time
+          readOnly: true
+          type: string
+        DeleteInProgress:
+          description: Delete of this organization is in progress
+          readOnly: true
+          type: boolean
+        EdgeboxOnly:
+          description: Edgebox only operator organization
+          readOnly: true
+          type: boolean
+        Name:
+          description: Organization name. Can only contain letters, digits, underscore,
+            period, hyphen. It cannot have leading or trailing spaces or period. It
+            cannot start with hyphen
+          type: string
+        Parent:
+          description: This organization's parent organization for billing, if any
+          readOnly: true
+          type: string
+        Phone:
+          description: Organization phone number
+          type: string
+        PublicImages:
+          description: Images are made available to other organization
+          readOnly: true
+          type: boolean
+        Type:
+          description: 'Organization type: "developer" or "operator"'
+          type: string
+        UpdatedAt:
+          description: Time last updated
+          format: date-time
+          readOnly: true
+          type: string
+      type: object
+    OrmapiPasswordReset:
+      properties:
+        password:
+          description: User's new password
+          type: string
+        token:
+          description: Authentication token
+          type: string
+      type: object
+    OrmapiPaymentProfileDeletion:
+      properties:
+        Id:
+          description: Payment Profile Id
+          type: integer
+        Org:
+          description: Billing Organization Name associated with the payment profile
+          type: string
+      type: object
+    OrmapiRegionAlert:
+      properties:
+        Alert:
+          $ref: '#/components/schemas/EdgeprotoAlert'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAlertPolicy:
+      properties:
+        AlertPolicy:
+          $ref: '#/components/schemas/EdgeprotoAlertPolicy'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionApp:
+      properties:
+        App:
+          $ref: '#/components/schemas/EdgeprotoApp'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAppAlertPolicy:
+      properties:
+        AppAlertPolicy:
+          $ref: '#/components/schemas/EdgeprotoAppAlertPolicy'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAppAutoProvPolicy:
+      properties:
+        AppAutoProvPolicy:
+          $ref: '#/components/schemas/EdgeprotoAppAutoProvPolicy'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAppInst:
+      properties:
+        AppInst:
+          $ref: '#/components/schemas/EdgeprotoAppInst'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAppInstClientKey:
+      properties:
+        AppInstClientKey:
+          $ref: '#/components/schemas/EdgeprotoAppInstClientKey'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAppInstEvents:
+      properties:
+        AppInst:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        Limit:
+          description: Display the last X metrics
+          type: integer
+        NumSamples:
+          description: Display X samples spaced out evenly over start and end times
+          type: integer
+        Region:
+          description: Region name
+          type: string
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionAppInstKey:
+      properties:
+        AppInstKey:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAppInstLatency:
+      properties:
+        AppInstLatency:
+          $ref: '#/components/schemas/EdgeprotoAppInstLatency'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAppInstMetrics:
+      properties:
+        AppInst:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        AppInsts:
+          description: Application instances to filter for metrics
+          items:
+            $ref: '#/components/schemas/EdgeprotoAppInstKey'
+          type: array
+        Limit:
+          description: Display the last X metrics
+          type: integer
+        NumSamples:
+          description: Display X samples spaced out evenly over start and end times
+          type: integer
+        Region:
+          description: Region name
+          type: string
+        Selector:
+          description: 'Comma separated list of metrics to view. Available metrics:
+            utilization, network, ipusage'
+          type: string
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionAppInstRefs:
+      properties:
+        AppInstRefs:
+          $ref: '#/components/schemas/EdgeprotoAppInstRefs'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAppInstUsage:
+      properties:
+        AppInst:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        EndTime:
+          description: Time up to which to display stats
+          format: date-time
+          type: string
+        Region:
+          description: Region name
+          type: string
+        StartTime:
+          description: Time to start displaying stats from
+          format: date-time
+          type: string
+        VmOnly:
+          description: Show only VM-based apps
+          type: boolean
+      type: object
+    OrmapiRegionAutoProvPolicy:
+      properties:
+        AutoProvPolicy:
+          $ref: '#/components/schemas/EdgeprotoAutoProvPolicy'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAutoProvPolicyCloudlet:
+      properties:
+        AutoProvPolicyCloudlet:
+          $ref: '#/components/schemas/EdgeprotoAutoProvPolicyCloudlet'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionAutoScalePolicy:
+      properties:
+        AutoScalePolicy:
+          $ref: '#/components/schemas/EdgeprotoAutoScalePolicy'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionClientApiUsageMetrics:
+      properties:
+        AppInst:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        DmeCloudlet:
+          description: Cloudlet name where DME is running
+          type: string
+        DmeCloudletOrg:
+          description: Operator organization where DME is running
+          type: string
+        Limit:
+          description: Display the last X metrics
+          type: integer
+        Method:
+          description: 'API call method, one of: FindCloudlet, PlatformFindCloudlet,
+            RegisterClient, VerifyLocation'
+          type: string
+        NumSamples:
+          description: Display X samples spaced out evenly over start and end times
+          type: integer
+        Region:
+          description: Region name
+          type: string
+        Selector:
+          description: 'Comma separated list of metrics to view. Available metrics:
+            utilization, network, ipusage'
+          type: string
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionClientAppUsageMetrics:
+      properties:
+        AppInst:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        DataNetworkType:
+          description: 'Data network type used by client device. Can be used for selectors:
+            latency'
+          type: string
+        DeviceCarrier:
+          description: 'Device carrier. Can be used for selectors: latency, deviceinfo'
+          type: string
+        DeviceModel:
+          description: 'Device model. Can be used for selectors: deviceinfo'
+          type: string
+        DeviceOs:
+          description: 'Device operating system. Can be used for selectors: deviceinfo'
+          type: string
+        Limit:
+          description: Display the last X metrics
+          type: integer
+        LocationTile:
+          description: 'Provides the range of GPS coordinates for the location tile/square.
+            Format is: ''LocationUnderLongitude,LocationUnderLatitude_LocationOverLongitude,LocationOverLatitude_LocationTileLength''.
+            LocationUnder are the GPS coordinates of the corner closest to (0,0) of
+            the location tile. LocationOver are the GPS coordinates of the corner
+            farthest from (0,0) of the location tile. LocationTileLength is the length
+            (in kilometers) of one side of the location tile square'
+          type: string
+        NumSamples:
+          description: Display X samples spaced out evenly over start and end times
+          type: integer
+        Region:
+          description: Region name
+          type: string
+        Selector:
+          description: 'Comma separated list of metrics to view. Available metrics:
+            utilization, network, ipusage'
+          type: string
+        SignalStrength:
+          description: Signal strength
+          type: string
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionClientCloudletUsageMetrics:
+      properties:
+        Cloudlet:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        DataNetworkType:
+          description: 'Data network type used by client device. Can be used for selectors:
+            latency'
+          type: string
+        DeviceCarrier:
+          description: 'Device carrier. Can be used for selectors: latency, deviceinfo'
+          type: string
+        DeviceModel:
+          description: 'Device model. Can be used for selectors: deviceinfo'
+          type: string
+        DeviceOs:
+          description: 'Device operating system. Can be used for selectors: deviceinfo'
+          type: string
+        Limit:
+          description: Display the last X metrics
+          type: integer
+        LocationTile:
+          description: 'Provides the range of GPS coordinates for the location tile/square.
+            Format is: ''LocationUnderLongitude,LocationUnderLatitude_LocationOverLongitude,LocationOverLatitude_LocationTileLength''.
+            LocationUnder are the GPS coordinates of the corner closest to (0,0) of
+            the location tile. LocationOver are the GPS coordinates of the corner
+            farthest from (0,0) of the location tile. LocationTileLength is the length
+            (in kilometers) of one side of the location tile square'
+          type: string
+        NumSamples:
+          description: Display X samples spaced out evenly over start and end times
+          type: integer
+        Region:
+          description: Region name
+          type: string
+        Selector:
+          description: 'Comma separated list of metrics to view. Available metrics:
+            utilization, network, ipusage'
+          type: string
+        SignalStrength:
+          description: Signal strength
+          type: string
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionCloudlet:
+      properties:
+        Cloudlet:
+          $ref: '#/components/schemas/EdgeprotoCloudlet'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCloudletAllianceOrg:
+      properties:
+        CloudletAllianceOrg:
+          $ref: '#/components/schemas/EdgeprotoCloudletAllianceOrg'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCloudletEvents:
+      properties:
+        Cloudlet:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        Limit:
+          description: Display the last X metrics
+          type: integer
+        NumSamples:
+          description: Display X samples spaced out evenly over start and end times
+          type: integer
+        Region:
+          description: Region name
+          type: string
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionCloudletInfo:
+      properties:
+        CloudletInfo:
+          $ref: '#/components/schemas/EdgeprotoCloudletInfo'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCloudletKey:
+      properties:
+        CloudletKey:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCloudletMetrics:
+      properties:
+        Cloudlet:
+          $ref: '#/components/schemas/EdgeprotoCloudletKey'
+        Cloudlets:
+          description: Cloudlet keys for metrics
+          items:
+            $ref: '#/components/schemas/EdgeprotoCloudletKey'
+          type: array
+        Limit:
+          description: Display the last X metrics
+          type: integer
+        NumSamples:
+          description: Display X samples spaced out evenly over start and end times
+          type: integer
+        Region:
+          description: Region name
+          type: string
+        Selector:
+          description: 'Comma separated list of metrics to view. Available metrics:
+            utilization, network, ipusage'
+          type: string
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionCloudletPool:
+      properties:
+        CloudletPool:
+          $ref: '#/components/schemas/EdgeprotoCloudletPool'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCloudletPoolMember:
+      properties:
+        CloudletPoolMember:
+          $ref: '#/components/schemas/EdgeprotoCloudletPoolMember'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCloudletPoolUsage:
+      properties:
+        CloudletPool:
+          $ref: '#/components/schemas/EdgeprotoCloudletPoolKey'
+        EndTime:
+          description: Time up to which to display stats
+          format: date-time
+          type: string
+        Region:
+          description: Region name
+          type: string
+        ShowVmAppsOnly:
+          description: Show only VM-based apps
+          type: boolean
+        StartTime:
+          description: Time to start displaying stats from
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionCloudletProps:
+      properties:
+        CloudletProps:
+          $ref: '#/components/schemas/EdgeprotoCloudletProps'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCloudletRefs:
+      properties:
+        CloudletRefs:
+          $ref: '#/components/schemas/EdgeprotoCloudletRefs'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCloudletResMap:
+      properties:
+        CloudletResMap:
+          $ref: '#/components/schemas/EdgeprotoCloudletResMap'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCloudletResourceQuotaProps:
+      properties:
+        CloudletResourceQuotaProps:
+          $ref: '#/components/schemas/EdgeprotoCloudletResourceQuotaProps'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCloudletResourceUsage:
+      properties:
+        CloudletResourceUsage:
+          $ref: '#/components/schemas/EdgeprotoCloudletResourceUsage'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionClusterInst:
+      properties:
+        ClusterInst:
+          $ref: '#/components/schemas/EdgeprotoClusterInst'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionClusterInstEvents:
+      properties:
+        ClusterInst:
+          $ref: '#/components/schemas/EdgeprotoClusterInstKey'
+        Limit:
+          description: Display the last X metrics
+          type: integer
+        NumSamples:
+          description: Display X samples spaced out evenly over start and end times
+          type: integer
+        Region:
+          description: Region name
+          type: string
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionClusterInstKey:
+      properties:
+        ClusterInstKey:
+          $ref: '#/components/schemas/EdgeprotoClusterInstKey'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionClusterInstMetrics:
+      properties:
+        ClusterInst:
+          $ref: '#/components/schemas/EdgeprotoClusterInstKey'
+        ClusterInsts:
+          description: Cluster instance keys for metrics
+          items:
+            $ref: '#/components/schemas/EdgeprotoClusterInstKey'
+          type: array
+        Limit:
+          description: Display the last X metrics
+          type: integer
+        NumSamples:
+          description: Display X samples spaced out evenly over start and end times
+          type: integer
+        Region:
+          description: Region name
+          type: string
+        Selector:
+          description: 'Comma separated list of metrics to view. Available metrics:
+            utilization, network, ipusage'
+          type: string
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionClusterInstUsage:
+      properties:
+        ClusterInst:
+          $ref: '#/components/schemas/EdgeprotoClusterInstKey'
+        EndTime:
+          description: Time up to which to display stats
+          format: date-time
+          type: string
+        Region:
+          description: Region name
+          type: string
+        StartTime:
+          description: Time to start displaying stats from
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionClusterRefs:
+      properties:
+        ClusterRefs:
+          $ref: '#/components/schemas/EdgeprotoClusterRefs'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionCustomAppMetrics:
+      properties:
+        AggrFunction:
+          description: Aggregation function (optional)
+          type: string
+        AppInst:
+          $ref: '#/components/schemas/EdgeprotoAppInstKey'
+        Limit:
+          description: Display the last X metrics
+          type: integer
+        Measurement:
+          description: 'Pre-built queries, one of: connections'
+          type: string
+        NumSamples:
+          description: Display X samples spaced out evenly over start and end times
+          type: integer
+        Port:
+          description: Port on AppInst (optional)
+          type: string
+        Region:
+          description: Region name
+          type: string
+        endage:
+          description: End age relative to now of the time range
+          type: string
+        endtime:
+          description: End time of the time range
+          format: date-time
+          type: string
+        startage:
+          description: Start age relative to now of the time range
+          type: string
+        starttime:
+          description: Start time of the time range
+          format: date-time
+          type: string
+      type: object
+    OrmapiRegionDebugRequest:
+      properties:
+        DebugRequest:
+          $ref: '#/components/schemas/EdgeprotoDebugRequest'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionDeploymentCloudletRequest:
+      properties:
+        DeploymentCloudletRequest:
+          $ref: '#/components/schemas/EdgeprotoDeploymentCloudletRequest'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionDevice:
+      properties:
+        Device:
+          $ref: '#/components/schemas/EdgeprotoDevice'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionDeviceReport:
+      properties:
+        DeviceReport:
+          $ref: '#/components/schemas/EdgeprotoDeviceReport'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionExecRequest:
+      properties:
+        ExecRequest:
+          $ref: '#/components/schemas/EdgeprotoExecRequest'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionFlavor:
+      properties:
+        Flavor:
+          $ref: '#/components/schemas/EdgeprotoFlavor'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionFlavorMatch:
+      properties:
+        FlavorMatch:
+          $ref: '#/components/schemas/EdgeprotoFlavorMatch'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionFlowRateLimitSettings:
+      properties:
+        FlowRateLimitSettings:
+          $ref: '#/components/schemas/EdgeprotoFlowRateLimitSettings'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionGPUDriver:
+      properties:
+        GPUDriver:
+          $ref: '#/components/schemas/EdgeprotoGPUDriver'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionGPUDriverBuildMember:
+      properties:
+        GPUDriverBuildMember:
+          $ref: '#/components/schemas/EdgeprotoGPUDriverBuildMember'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionGPUDriverKey:
+      properties:
+        GPUDriverKey:
+          $ref: '#/components/schemas/EdgeprotoGPUDriverKey'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionIdleReservableClusterInsts:
+      properties:
+        IdleReservableClusterInsts:
+          $ref: '#/components/schemas/EdgeprotoIdleReservableClusterInsts'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionMaxReqsRateLimitSettings:
+      properties:
+        MaxReqsRateLimitSettings:
+          $ref: '#/components/schemas/EdgeprotoMaxReqsRateLimitSettings'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionNetwork:
+      properties:
+        Network:
+          $ref: '#/components/schemas/EdgeprotoNetwork'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionNode:
+      properties:
+        Node:
+          $ref: '#/components/schemas/EdgeprotoNode'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionOperatorCode:
+      properties:
+        OperatorCode:
+          $ref: '#/components/schemas/EdgeprotoOperatorCode'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionRateLimitSettings:
+      properties:
+        RateLimitSettings:
+          $ref: '#/components/schemas/EdgeprotoRateLimitSettings'
+        Region:
+          description: Region name
+          type: string
+      type: object
+    OrmapiRegionResTagTable:
+      properties:
+        Region:
+          description: Region name
+          type: string
+        ResTagTable:
+          $ref: '#/components/schemas/EdgeprotoResTagTable'
+      type: object
+    OrmapiRegionResTagTableKey:
+      properties:
+        Region:
+          description: Region name
+          type: string
+        ResTagTableKey:
+          $ref: '#/components/schemas/EdgeprotoResTagTableKey'
+      type: object
+    OrmapiRegionSettings:
+      properties:
+        Region:
+          description: Region name
+          type: string
+        Settings:
+          $ref: '#/components/schemas/EdgeprotoSettings'
+      type: object
+    OrmapiRegionTrustPolicy:
+      properties:
+        Region:
+          description: Region name
+          type: string
+        TrustPolicy:
+          $ref: '#/components/schemas/EdgeprotoTrustPolicy'
+      type: object
+    OrmapiRegionTrustPolicyException:
+      properties:
+        Region:
+          description: Region name
+          type: string
+        TrustPolicyException:
+          $ref: '#/components/schemas/EdgeprotoTrustPolicyException'
+      type: object
+    OrmapiRegionVMPool:
+      properties:
+        Region:
+          description: Region name
+          type: string
+        VMPool:
+          $ref: '#/components/schemas/EdgeprotoVMPool'
+      type: object
+    OrmapiRegionVMPoolMember:
+      properties:
+        Region:
+          description: Region name
+          type: string
+        VMPoolMember:
+          $ref: '#/components/schemas/EdgeprotoVMPoolMember'
+      type: object
+    OrmapiReporter:
+      properties:
+        Email:
+          description: Email to send generated reports
+          type: string
+        Name:
+          description: Reporter name. Can only contain letters, digits, period, hyphen.
+            It cannot have leading or trailing spaces or period. It cannot start with
+            hyphen
+          type: string
+        NextScheduleDate:
+          description: Date when the next report is scheduled to be generated (for
+            internal use only)
+          readOnly: true
+          type: string
+        Org:
+          description: Organization name
+          type: string
+        Schedule:
+          description: Indicates how often a report should be generated, one of EveryWeek,
+            Every15Days, EveryMonth, valid values are one of EveryWeek, Every15Days,
+            EveryMonth, or 0, 1, 3
+          type: string
+        StartScheduleDate:
+          description: 'Start date (in RFC3339 format with intended timezone) when
+            the report is scheduled to be generated (Default: today)'
+          type: string
+        Status:
+          description: Last report status
+          readOnly: true
+          type: string
+        Timezone:
+          description: Timezone in which to show the reports, defaults to UTC
+          type: string
+        Username:
+          description: User name (for internal use only)
+          readOnly: true
+          type: string
+      type: object
+    OrmapiResult:
+      properties:
+        code:
+          description: Error code
+          type: integer
+        message:
+          description: Informational message
+          type: string
+      type: object
+    OrmapiRole:
+      properties:
+        org:
+          description: Organization name
+          type: string
+        role:
+          description: Role which defines the set of permissions
+          type: string
+        username:
+          description: User name
+          type: string
+      type: object
+    OrmapiRolePerm:
+      properties:
+        action:
+          description: Action defines what type of action can be performed on a resource
+          type: string
+        resource:
+          description: Resource defines a resource to act upon
+          type: string
+        role:
+          description: Role defines a collection of permissions, which are resource-action
+            pairs
+          type: string
+      type: object
+    OrmapiShowUser:
+      properties:
+        CreatedAt:
+          description: Time created
+          format: date-time
+          readOnly: true
+          type: string
+        Email:
+          description: User email
+          type: string
+        EmailVerified:
+          description: Email address has been verified
+          readOnly: true
+          type: boolean
+        EnableTOTP:
+          description: Enable or disable temporary one-time passwords for the account
+          type: boolean
+        FailedLogins:
+          description: Number of failed login attempts since last successful login
+          type: integer
+        FamilyName:
+          description: Family Name
+          type: string
+        GivenName:
+          description: Given Name
+          type: string
+        LastFailedLogin:
+          description: Last failed login time
+          format: date-time
+          readOnly: true
+          type: string
+        LastLogin:
+          description: Last successful login time
+          format: date-time
+          readOnly: true
+          type: string
+        Locked:
+          description: Account is locked
+          readOnly: true
+          type: boolean
+        Metadata:
+          description: Metadata
+          type: string
+        Name:
+          description: User name. Can only contain letters, digits, underscore, period,
+            hyphen. It cannot have leading or trailing spaces or period. It cannot
+            start with hyphen
+          type: string
+        Nickname:
+          description: Nick Name
+          type: string
+        PassCrackTimeSec:
+          description: Password strength in terms of brute-force cracking time
+          readOnly: true
+          type: number
+        Picture:
+          description: Picture (currently not used)
+          type: string
+        UpdatedAt:
+          description: Time last updated
+          format: date-time
+          readOnly: true
+          type: string
+        org:
+          description: Organization name
+          type: string
+        role:
+          description: Role name
+          type: string
+      type: object
+    OrmapiToken:
+      properties:
+        token:
+          description: Authentication token
+          type: string
+      type: object
+    OrmapiUser:
+      properties:
+        CreatedAt:
+          description: Time created
+          format: date-time
+          readOnly: true
+          type: string
+        Email:
+          description: User email
+          type: string
+        EmailVerified:
+          description: Email address has been verified
+          readOnly: true
+          type: boolean
+        EnableTOTP:
+          description: Enable or disable temporary one-time passwords for the account
+          type: boolean
+        FailedLogins:
+          description: Number of failed login attempts since last successful login
+          type: integer
+        FamilyName:
+          description: Family Name
+          type: string
+        GivenName:
+          description: Given Name
+          type: string
+        LastFailedLogin:
+          description: Last failed login time
+          format: date-time
+          readOnly: true
+          type: string
+        LastLogin:
+          description: Last successful login time
+          format: date-time
+          readOnly: true
+          type: string
+        Locked:
+          description: Account is locked
+          readOnly: true
+          type: boolean
+        Metadata:
+          description: Metadata
+          type: string
+        Name:
+          description: User name. Can only contain letters, digits, underscore, period,
+            hyphen. It cannot have leading or trailing spaces or period. It cannot
+            start with hyphen
+          type: string
+        Nickname:
+          description: Nick Name
+          type: string
+        PassCrackTimeSec:
+          description: Password strength in terms of brute-force cracking time
+          readOnly: true
+          type: number
+        Picture:
+          description: Picture (currently not used)
+          type: string
+        UpdatedAt:
+          description: Time last updated
+          format: date-time
+          readOnly: true
+          type: string
+      type: object
+    OrmapiUserLogin:
+      properties:
+        apikey:
+          description: API key if logging in using API key
+          type: string
+        apikeyid:
+          description: API key ID if logging in using API key
+          type: string
+        password:
+          description: User's password
+          type: string
+        totp:
+          description: Temporary one-time password if 2-factor authentication is enabled
+          type: string
+        username:
+          description: User's name or email address
+          type: string
+      type: object
+    OrmapiUserResponse:
+      properties:
+        Message:
+          description: Message
+          type: string
+        TOTPQRImage:
+          description: TOTP QR image
+          items:
+            minimum: 0
+            type: integer
+          nullable: true
+          type: array
+        TOTPSharedKey:
+          description: TOTP shared key
+          type: string
+      type: object
+    OrmapiVersion:
+      properties:
+        buildauthor:
+          description: Build author
+          type: string
+        buildhead:
+          description: Head build version
+          type: string
+        buildmaster:
+          description: Master build version
+          type: string
+        hostname:
+          description: Hostname that performed build
+          type: string
+      type: object
+    PqStringArray:
+      items:
+        type: string
+      nullable: true
+      type: array
+    TypesTimestamp:
+      properties:
+        nanos:
+          description: Non-negative fractions of a second at nanosecond resolution.
+            Negative second values with fractions must still have non-negative nanos
+            values that count forward in time. Must be from 0 to 999,999,999 inclusive.
+          type: integer
+        seconds:
+          description: Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z.
+            Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+          type: integer
+      type: object
+  securitySchemes:
+    bearerAuth:
+      bearerFormat: JWT
+      description: JWT token generated by the login API to be included in the http
+        header
+      scheme: bearer
+      type: http
+x-tagGroups:
+- name: Auth & User Management API
+  tags:
+  - Security
+  - User
+  - Role
+  - Org
+- name: Operator API
+  tags:
+  - Cloudlet
+  - OperatorCode
+  - Flavor
+  - CloudletProps
+  - CloudletResMap
+  - FlavorMatch
+  - CloudletPool
+  - CloudletPoolMember
+  - VMPool
+  - VMPoolMember
+  - OperatorMetrics
+  - Events
+  - OperatorUsage
+  - AlertReceiver
+  - Network
+- name: Developer API
+  tags:
+  - ClusterInst
+  - App
+  - AppInst
+  - AutoProvPolicy
+  - AppAutoProvPolicy
+  - AutoScalePolicy
+  - PrivacyPolicy
+  - AutoProvPolicyCloudlet
+  - AppInstClientKey
+  - ExecRequest
+  - DeveloperMetrics
+  - Events
+  - DeveloperUsage
+  - AlertReceiver


### PR DESCRIPTION
This adds the full EdgeXR platform North Bound (user facing) APIs. Previously, the App.yaml only provided App definition APIs. This openapi spec includes those App APIs plus all our other APIs for managing instances, cloudlets, policies, resources, etc.