### PR TITLE
V0.9.2

### DIFF
--- a/code/API_definitions/Traffic Influence/Traffic_Influence.yaml
+++ b/code/API_definitions/Traffic Influence/Traffic_Influence.yaml
@@ -1,85 +1,89 @@
-openapi: 3.0.0
+openapi: 3.0.3
 ############################################################################
 #                                     API info                             #
 ############################################################################
 info:
   title: OPAG-CAMARA Traffic Influence API
-  version: 0.8.1
+  version: 0.9.2
   description: |
     ## Overview
     
-    The reference scenario foresees a Service owned by a Developer, composed by one or more Service Producers provided by the Developer and deployed in different geographical locations on Telco Operator Edge sites (MEC sites) or in Cloud. The Service Producer, deployed at the Edge, is referred as Edge Application Server (EAS).
-    The Traffic Influence API provides the fastest routing from the user equipment (e.g. a Smartphone) to the optimal Edge Application Server (EAS) Instance in a specific geographical location, installed in a Telco Operator Edge site.
-    If a Service is offered by a Cloud Instance and by Edge Instances, the API can be used to route a selected set of users on the Edge Instance.
+    The reference scenario foresees a Service, composed by one or more Service Producers deployed in different geographical locations on Telco Edge sites (Edge datacentres of Telco Operator) or in Cloud. The Service Producer, deployed at the Edge, is referred as Edge Application Server (EAS).
+    The Traffic Influence API (TI API) provides the fastest routing from the user Device (e.g. a Smartphone) to the optimal EAS instance in a specific geographical location, installed in a Telco Edge site.
+    If a Service is offered by Cloud Instances and by Edge Instances, the TI API can be used get the optimal routing of the traffic to the Edge Instances, maybe for a set of users. Getting the optimal routing can be used to improve latency maybe in combination with other CAMARA APIs such as QoD (Quality On Demand). Providing the optimal routing is indeed an important step to get the optimal latency.
+    If the TI API is used to get the best routing at the Edge for a Device in a geographical location and the Device moves to another geographical location, the TI API can be invoked to get the optimal routing in the new geographical location for that Device.
     
     ## 1. Introduction
-   
-    The Traffic Influence API provides the capability to establish the best connectivity, in terms of latency, in a specific geographical area, between the User Equipment (UE), e.g. the user’s smartphone, and the optimal Edge Application Server instance nearby.
-    The Service architecture foresees one or more EASs and a component, the Application Function (AF), that is the API consumer. Invoking the TI API, the AF can create a "TrafficInfluence" resource specifying the desired request.
-    The TI API provider implements the intent specified in the Traffic Influence resource.
-    While the API is usually invoked to activate the fastest routing for any user,  it can also be used to request the routing for a specific user. Invoking the API for each user (using the same "trafficInfluenceID"), the "TrafficInfluence" resource provides the requested routing for a set of users.
+    The TI API provides the capability to establish the best routing, in terms of latency, in a specific geographical area, between the user Device, e.g. the user’s smartphone, and the optimal EAS instance nearby. If the Device moves in a different geographical location where a more suitable EAS instance is available, the TI API can be invoked to influence the Device connectivity to get the optimal routing to the that local instance. It is important to notice that it is a task of the Application invoking the TI API to detect the changes in the Device location. 
+    The generic architecture for the Service can foresee some Cloud instances of the Application, one or more Edge Instances of the Application. A component of the Service is the TI API Consumer. This logical component can be integrated in other components of the Service to invoke the TI API, creating a "TrafficInfluence" resource specifying the desired intent.
+    The TI API Producer implements the intent specified in the "TrafficInfluence" resource.
+    While the TI API can be invoked to activate the fastest routing for any user, it can also be used to request the best routing for a specific user. Invoking the TI API for each user, many "TrafficInfluence" resources are created for each user to provide the requested routing for a set of users.
+    The same approach is used for the geographical locations where the influence of the traffic must be applied. Invoking the TI API without specifying a geographical area activates the optimal routing toward any EAS instance, while invoking the TI API specifying a geographical area activates the optimal routing only toward the EAS instance located closest to that geographical area. To activate the optimal routing in selected geographical areas, the TI API must be invoked for each geographical area.
+    The TI API can be used to:
+        - optimise the routing when Devices need to consume the service provided by a local EAS Instances.
+        - effect an already established Device routing when the Device moves among different geographical locations. When the TI API consumer detects a Device has entered a geographical location where an EAS instance is available, it can invoke the TI API to get the optimal routing toward that EAS instance. If the Device moves to another geographical location, served by another EAS instance, the routing might not be optimal anymore for the new EAS instance. In the case the Application detects a location change, it can invoke the TI API again to request a new routing optimization toward the new EAS instance.   
     
     ## 2. Quick Start
-    The usage of the Traffic Influence API is based on the management of a "TrafficInfluence" resource, an object containing the intent requested invoking the Traffic Influence API and that is implemented by the platform configuring the Mobile Network for the optimal routing toward the EAS Instance.
+    The usage of the TI API is based on the management of a "TrafficInfluence" resource, an object containing the intent requested invoking the TI API and that is implemented by the platform configuring the Mobile Network for the optimal routing toward the EAS instance.
     The "TrafficInfluence" resource can be created (providing the related parameters that specify the desired intent), queried, modified and deleted.
-    The API is asynchronous, a notification is available providing information about the status of the requested resource.  
+    The TI API is asynchronous, a notification is available providing information about the status of the requested resource.  
     For an Application (identified by "applicationId") many "TrafficInfluence" resources can be created, e.g. to add multiple users, regions or zones. 
     
-    Before starting to use the API, the developer needs to know about the below specified details:
+    Before starting to use the TI API, the developer needs to know about the below specified details:
    
     **Base-Url**
-    The RESTful Traffic Influence API endpoint, for example [**https://tim-api.developer.tim.it/trafficinfluence**](https://tim-api.developer.tim.it/trafficinfluence)
+    The RESTful TI API endpoint, for example [**https://tim-api.developer.tim.it/trafficinfluence**](https://tim-api.developer.tim.it/trafficinfluence)
    
     **Authentication**
-    Configure security access keys such as OAuth 2.0 client credentials to be used by Client applications which will invoke the Traffic InfluenceAPI.
+    Configure security access keys such as OAuth 2.0 client credentials to be used by Client applications which will invoke the TI API.
    
     **TrafficInfluence**
-    This object represents the resource that carries the requirements from the user to be implemented. The Traffic Influence API is invoked for the life cycle management of this resource (CRUD). The resource contains the intents from the API Consumer. Managing this resource, the developer can specify in which geographical location the routing must be applied, toward which application,  maybe for a specific set of users or for a limited period pf time.
+    This object represents the resource that carries the requirements from the user to be implemented. The TI API is invoked for the life cycle management of this resource (CRUD). The resource contains the intents from the TI API Consumer. Managing this resource, the developer can specify in which geographical location the routing must be applied, toward which application, maybe for a specific set of users or for a limited period of time.
    
     **trafficInfluenceID**
-    Identifier for the Traffic Influence resource. This parameter ir returned by the API and must be used to update it (e.g., adding new users or deleting it)
+    Identifier for the Traffic Influence resource. This parameter is returned by the TI API and must be used to update it (e.g., adding a Device or deleting it). A different Traffic Influence resource must be created for any Device or Zone or Region. All these resources are related to an Application identified by the applicationId.
     
-    **applicationFunctionId**
-    Unique identifier for the Application Function (AF), the TI API consumer.
+    **apiConsumerId**
+    Unique identifier for the TI API Consumer.
     
     **region**
-    The developer can specify in which geographical area he requires the fastest routing toward the nearest application instance. A Region is a wide geographical area and it contains one ore more Zones. A Zone is where the Edge Datacenters are located. Zones and Regions identifiers are defined and provided by the Telco Operator and can also be used or retrieved with other CAMARA APIs ("MEC Exposure & Experience Management API" and "Simple Edge Discovery"). To add more regions the API must be invoked (PUT) of each region. New "TrafficInfluence" resources are created (with different "trafficInfluenceID"). All the created resources are aggregated by the Application (identified by "applicationId").
+    The developer can specify in which geographical area he requires the fastest routing toward the nearest application instance. A Region is a wide geographical area and it contains one or more Zones. A Zone is where the Telco Edge sites are located. Zones and Regions identifiers are defined and provided by the Telco Operator and can also be used or retrieved with other CAMARA APIs (“MEC Exposure & Experience Management API” and “Simple Edge Discovery”). To add more regions the TI API must be invoked (POST) for each region. New "TrafficInfluence" resources are created (with different "trafficInfluenceID"). All the created resources are aggregated by the Application (identified by "applicationId").
     
     **zone**
-    The developer can specify in which geographical area he requires the fastest routing toward the nearest application instance. A Zone is a smaller geographical area inside a Region. A Zone is where the Edge Datacenters are located. To add more zones the API must be invoked (PUT) of each zone. New "TrafficInfluence" resources are created (with different "trafficInfluenceID"). All the created resources are aggregated by the Application (identified by "applicationId").
+    The developer can specify in which geographical area he requires the fastest routing toward the nearest Application instance. A Zone is a smaller geographical area inside a Region. A Zone is where the Telco Edge sites are located. To add more zones the TI API must be invoked (POST) for each zone. New "TrafficInfluence" resources are created (with different "trafficInfluenceID"). All the created resources are aggregated by the Application (identified by "applicationId").
     
     **applicationId**
-    Unique Application identifier inside the Telco Operator Platform.
+    Unique Application identifier inside the Telco Operator Platform. This identifier is provided during the application onboarding process. To influence the traffic toward a specific Application. It is the Operator Platform that detects the appropriate Application instance in the selected Region or Zone.
+    
+    **instanceId**
+    Unique identifier generated by the Operator Platform to identify a specific instance of the Application on a specific zone. To influence a traffic toward a specific Application instance.
    
     **trafficFilters**
     The Application can expose different service on different interfaces, with this parameter it is possible to enable just some of those services maybe for different sets of users.
    
-    **usersId**
-    Optionally a user can be provided as an input. To add more users the API must be invoked (PUT) of each user. New "TrafficInfluence" resources are created (with different "trafficInfluenceID"). All the created resources are aggregated by the Applicatoin (identified by "applicatoinId"). The routing toward the selected Application Instance is only applied for provided users.
+    **Device**
+    A user Device can be provided as an input. To add more users the TI API must be invoked (POST) of each user Device. New "TrafficInfluence" resources are created (with different "trafficInfluenceID"). All the created resources are aggregated by the Application (identified by "applicationId"). The routing toward the selected Application instance is only applied for provided user Devices.
    
     **Notification URL and token**
-    Developers have a chance to specify callback URL on which notifications (eg. session termination) regarding the session can be received from the service provider. This is also an optional parameter.
+    Developers have a chance to specify call back URL on which notifications (e.g. session termination) regarding the session can be received from the service provider. This is also an optional parameter.
           
     ## 3. Authentication and Authorization
-    The Traffic Influence API makes use of the client credentials grant which is applicable for server to server use cases involving trusted partners or clients without any protected user data involved.
-    In this method the API invoker client is registered as a confidential client with an authorization grant type of client\_credentials [2].
+    The TI API makes use of the client credentials grant which is applicable for server to server use cases involving trusted partners or clients without any protected user data involved.
+    In this method the TI API invoker client is registered as a confidential client with an authorization grant type of client\_credentials [2].
     
     ## 4. API Documentation
     ## 4.1 Details
     
-    The Traffic Influence (TI) API is consumed by an Application Function (AF) requesting for the fastest routing of the traffic flow from the User Equipments toward an instance of the Edge Application Server (EAS) in a Telco Operator Edge sites (MEC sites).
-    
-    When the EAS is onboarded and deployed in the MEC site, the Application is identified with a unique identifier (applicationId). 
-    
-    Using the application identifier ("applicationId") and specifying a Zone or a Region, the Telco Operator Platform, autonomously identifies the best instance of the EAS toward routing the traffic flow and configures the Mobile Network accordingly to get the fastest routing.
-    If just the application identifier is used, the Telco Operator Platform  identifies all the EAS Instances and activates the optimal routing on the Mobile Network.
-    If the fastest routing should be available just for a set of users, the API must be invoked for each user also passing the same TrafficInfluce resource identifier ("trafficInfluenceID")
-    If the Application offers different services on different interfaces a  traffic filter based on IP, Port and Protocol can be used. I this way it is also possible to redirect different users to different interfaces.
-   
+    The TI API is consumed by an Application Function (AF) requesting for the optimal routing, in term of latency, for the traffic flow from a Device toward EAS instances in Telco Edge sites.
+    When the Application (the EAS) is onboarded and deployed in the Telco Edge site, the Application is identified with a unique identifier (applicationId). 
+    Using the application identifier ("applicationId") and specifying a Zone or a Region, the Telco Operator Platform, autonomously identifies the best instance of the EAS toward which routing the traffic flow and configures the Mobile Network accordingly to get the fastest routing.
+    If just the application identifier is used, the Telco Operator Platform identifies all the EAS Instances and activates the optimal routing on the Mobile Network.
+    If the optimal routing in term of latency should be available just for a set of users, the TI API must be invoked for each user creating a new TrafficInfluce resource for each one.
+    If the Application offers different services on different interfaces a traffic filter based on IP, Port and Protocol can be used. I this way it is also possible to redirect different users to different interfaces.
     Here are some possible intents:
-    1) activate the optimal routing for any EAS Instance: the API must be invoked with the applicationId. The Telco Operator Platform identifies all the EAS Instances and activates the optimal routing on the Mobile Network.
-    2) activate the optimal routing in a specific Region or Zone: the API must be invoked with the applicationId and the Zones and Regions identifiers. 
-    3) activate the optimal routing for a specific set of users: the API can also be invoked with a user identifier ("userId"). The same TrafficInfluce resource identifier ("trafficInfluenceID") must be used in each call.
+    1) activate the optimal routing for any EAS instance: the TI API must be invoked with the applicationId. The Telco Operator Platform identifies all the EAS instances and activates the optimal routing on the Mobile Network.
+    2) activate the optimal routing in a specific Region or Zone: the TI API must be invoked with the applicationId and the Zones and Regions identifiers. 
+    3) activate the optimal routing for a user devices: the TI API can  be invoked with a user Device identifier (“Device”). For each user Device, a TI API invocation is required.
     
   license:
     name: Apache 2.0
@@ -128,7 +132,7 @@ paths:
       tags:
         - Traffic Influence API GET Operation
       summary: Retries existing TrafficInfluence Resources
-      description: Reads all of the active TrafficInfluence resources owned by the AF authenticated via oAuth2
+      description: Reads all of the active TrafficInfluence resources owned by the same API Consumer authenticated via oAuth2
       operationId: GetTrafficInfluences
       responses:
         '200':
@@ -154,7 +158,7 @@ paths:
       tags:
         - Traffic Influence API POST Operation
       summary: Creates a new TrafficInfluence resource
-      description: Gets in input an object containing the intents from the AF and creates a TrafficInfluence resourse accordingly. The trafficInfluenceID parameter, that is part of the object, must not be valorized when creating a new resource. It is automatically generated by the system and returned the response
+      description: Gets in input an object containing the intents from the API Consumer and creates a TrafficInfluence resourse accordingly. The trafficInfluenceID parameter, that is part of the object, must not be valorized when creating a new resource. For this reason the trafficInfluenceID parameter must be avoided in the object, anyway it will be ignored by the API Producer. It is automatically generated by the system and returned in the response.
       operationId: PostTrafficInfluence
       requestBody:
         description: Describes the request body
@@ -162,11 +166,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TrafficInfluence'
+              $ref: '#/components/schemas/PostTrafficInfluence'
 
       responses:
         '201':
-          description: TrafficInfluence resource created, the related object is returned with the resource ID (TIResource_id) and status (state) valorised, 
+          description: TrafficInfluence resource created, the related object is returned with the resource ID (trafficInfluenceID) and status (state) valorised, 
           headers:
             Location:
               description: Link to the created traffic influence resource
@@ -177,7 +181,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TrafficInfluence'
-
+        "400":
+          $ref: "#/components/responses/Generic400"   
         '500':
           $ref: '#/components/responses/GenericError'
         '504':
@@ -191,9 +196,9 @@ paths:
       callbacks:
         onTrafficInfluenceChanged:
           $ref: "#/components/callbacks/onTrafficInfluenceChanged"
-  /traffic-influences/{TIResource_id}:
+  /traffic-influences/{trafficInfluenceID}:
     parameters:
-      - name: TIResource_id
+      - name: trafficInfluenceID
         in: path
         description: Identifier of the specific TrafficInfluence resource to be retrieved, modified or deleted. It is the value used to fill trafficInfluenceID parameter
         required: true
@@ -201,7 +206,7 @@ paths:
           type: string
    
     get:
-      summary: read a specific TrafficInfluence resource identified by the TIResource_id value
+      summary: read a specific TrafficInfluence resource identified by the trafficInfluenceID value
       tags:
         - Traffic Influence API GET Operation
       responses:
@@ -223,19 +228,19 @@ paths:
           $ref: "#/components/responses/Generic403"
         "503":
           $ref: "#/components/responses/Generic503"
-    put:
+    patch:
       tags:
-        - TrafficInfluence API PUT Operation
-      summary: updates a specific TrafficInfluence resource, identified by the TIResource_id value
-      description: The resource identified by the TIResource_id value can be modified
-      operationId: PutTrafficInfluence
+        - TrafficInfluence API PATCH Operation
+      summary: updates a specific TrafficInfluence resource, identified by the trafficInfluenceID value
+      description: The resource identified by the trafficInfluenceID value can be modified
+      operationId: PatchTrafficInfluence
       requestBody:
         description: Describes the request body
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TrafficInfluence'
+              $ref: '#/components/schemas/PatchTrafficInfluence'
       responses:
         '200':
           description: TrafficInfluence resource edited, the related object is returned,  the status (state) is updated. 
@@ -249,6 +254,8 @@ paths:
               schema:
                 type: string
                 description: Link to the created traffic influence resource
+        "400":
+          $ref: "#/components/responses/Generic400"   
         '404':
           $ref: '#/components/responses/ResNotFound'
         '500':
@@ -280,8 +287,8 @@ paths:
             format: uri
             example: https://my-notification-server.com
       responses:
-        '200':
-          $ref: '#/components/responses/OkDeleted'
+        '202':
+          $ref: '#/components/responses/OkDeletionInProgress'
         '404':
           $ref: '#/components/responses/ResNotFound'
         '504':
@@ -336,47 +343,48 @@ components:
  #  RESOURCES
  #######################################################
   
-  schemas: 
-    TrafficInfluenceNotification:
-      type: object
-      required:
-        - trafficInfluenceChanged
-      properties:
-        trafficInfluenceChanged:
-          $ref: "#/components/schemas/TrafficInfluence"
+  schemas:
 
     TrafficInfluence:
       type: object
       properties:
         trafficInfluenceID:
           type: string
-          description: Identifier for the Traffic Influence resource. This parameter ir returned by the API and must be used to update it (e.g., adding new users or deleting it) passing it as TIResource_id value in the API call.
-        applicationFunctionId:
+          description: Identifier for the Traffic Influence resource. This parameter is returned by the API and must be used to update it (e.g., adding new users or deleting it).
+        apiConsumerId:
             type: string
-            description: Unique Identifier of the Application Function, the TI API consumer.
+            description: Unique Identifier of the TI API Consumer.
         applicationId:
           type: string
           example: "Virtual_Reality_Arena"
           description:  Unique ID representing the Edge Application
+        instanceId:
+            $ref: '#/components/schemas/InstanceIdentifier'
         region:
-            $ref: '#/components/schemas/types_region_Id'
+            $ref: '#/components/schemas/TypesRegionId'
         zone:
-            $ref: '#/components/schemas/types_zone_Id'
-        userId:
-          $ref: '#/components/schemas/userId'
+            $ref: '#/components/schemas/TypesZoneId'
+        device:
+          $ref: '#/components/schemas/Device'
         state:
           type: string
+          description: it reports the state of the TrafficInfluence resource. When first invoked, the resource is 'ordered'. When the platforms prepares the resource, it is 'created'. When the new routing is enabled in the network, the state is 'active'.  If an error occurs in the resource creation or in its activation, the state is 'error'. When the DELETE method is invoked the state is 'deletion in progress'. After the resource is deleted (as a consequence of the previous invokation of the DELETE method) the state is 'deleted'.
           enum:
             - 'ordered'
             - 'created'
             - 'active'
-            - 'not active'
             - 'error'
+            - 'deletion in progress'
             - 'deleted'
         trafficFilters:
           type: array
           items:
-            $ref: '#/components/schemas/FlowInfo'
+            type: string
+            description: Indicates the packet filters of the IP flow. The source IP is not required. It is retrived by the platoform according to the TI API request. If no Traffic Influece resourse is created with a specific Device, any IP will be routed to the Application. If a Traffic Influece resource exists with a specific Device configured, only the related IPs will be routed to the local instance of the Application. The destination IP is not required, it is already known by the platform thanks to the applicationId and InstanceIdentifier parameters that are used to retive the destination IP. The protocol must be specified and it is identified by a string according to the column “Keyword” as defined by IANA (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml), e.g. UDP or TCP.  The destination port must be specified.
+            example: TCP 5060
+            minItems: 1
+
+
           minItems: 1
           description: Identifies IP packet filters. To be used when a the Application needs a traffic flow towards a specific EAS interface 
         notificationUri:
@@ -386,64 +394,112 @@ components:
             type: string
             description: Authentification token for callback API      
       required:
-        - applicationFunctionId
+        - apiConsumerId
         - applicationId
+        
+    PatchTrafficInfluence:
+      allOf:
+        - $ref: "#/components/schemas/TrafficInfluence"
+      properties:
+        trafficInfluenceID:
+          readOnly: true
+        apiConsumerId:
+          readOnly: true
+        applicationId:
+          readOnly: true
+        state:
+          readOnly: true
+
+    PostTrafficInfluence:
+      allOf:
+        - $ref: "#/components/schemas/TrafficInfluence"
+      properties:
+        trafficInfluenceID:
+          readOnly: true
+        state:
+          readOnly: true
+    
+    TrafficInfluenceNotification:
+      type: object
+      required:
+        - trafficInfluenceChanged
+      properties:
+        trafficInfluenceChanged:
+          $ref: "#/components/schemas/TrafficInfluence"
+
     
  #######################################################
  #  TYPES
  #######################################################    
-    types_zone_Id:
+    TypesZoneId:
       description: |
         Unique identifier representing a zone
       type: string
       additionalProperties: false  
       
-    types_region_Id:
+    TypesRegionId:
       description: |
         Unique identifier representing a region
       type: string
       additionalProperties: false   
       
-    userId:
-     description: User equipment identifier, it is composed by a value and a type for that value
-     type: object
-     minProperties: 1
-     properties:
-       UEIdentityType:
-         $ref: "#/components/schemas/types_UEIdentityType"
-       UEIdentity:
-         $ref: "#/components/schemas/types_UEIdentity"
-  
-    types_UEIdentityType:
-      description: Type of User Equipment identifier used in `UEIdentity`.
-      type: string
-      enum:
-        - IPAddress
-        - MSISDN
-        - IMEI
-        - MDN
-        - GPSI
-        
-    types_UEIdentity:
-      description: Identifier value for User Equipment. The type of identifier is defined by the 'UEIdentityType' parameter.
-      type: string      
-
-    FlowInfo:
+    Device:
       type: object
+      minProperties: 1
       properties:
-        flowId:
-          type: integer
-          description: Indicates the IP flow.  
-        flowDescriptions:
-          type: array
-          items:
-            type: string
-          description: Indicates the packet filters of the IP flow. The source IP is according to the TI API request, any IP (if no userId is provided) or the IP related to userId so it doesn't need to be specified int flowDescription. The protocol is identified by a number as defined by IANA (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml), e.g. 1 (UDP) or 2 (TCP).  The destination IP and port must be specified.
-          example: protocol 1 to 10.98.0.0/24 5060
-          minItems: 1
-          maxItems: 2
-      required:
-        - flowId
+        phoneNumber:
+          $ref: "#/components/schemas/PhoneNumber"
+        networkAccessIdentifier:
+          $ref: "#/components/schemas/NetworkAccessIdentifier"
+        ipv4Address:
+          $ref: "#/components/schemas/Ipv4Address"
+        ipv6Address:
+          $ref: "#/components/schemas/Ipv6Address"
+      description: Device identifier
+    
+    NetworkAccessIdentifier:
+      type: string
+      example: "123456789@domain.com"
+   
+    PhoneNumber:
+      type: string
+      pattern: '^\+?[0-9]{5,15}$'
+      example: "123456789"
+      description: Subscriber number in E.164 format (starting with country code). Optionally prefixed with '+'.
+   
+    Ipv4Address:
+      type: string
+      format: ipv4
+      pattern: '^([01]?\d\d?|2[0-4]\d|25[0-5])(?:\.(?:[01]?\d\d?|2[0-4]\d|25[0-5])){3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$'
+      example: "192.168.0.1/24"
+      description: |
+        IPv4 address may be specified in form <address/mask> as:
+          - address - an IPv4 number in dotted-quad form 1.2.3.4. Only this exact IP number will match the flow control rule.
+          - address/mask - an IP number as above with a mask width of the form 1.2.3.4/24.
+            In this case, all IP numbers from 1.2.3.0 to 1.2.3.255 will match. The bit width MUST be valid for the IP version.
+   
+    Ipv6Address:
+      type: string
+      format: ipv6
+      allOf:
+        - pattern: '^((:|(0?|([1-9a-f][0-9a-f]{0,3}))):)((0?|([1-9a-f][0-9a-f]{0,3})):){0,6}(:|(0?|([1-9a-f][0-9a-f]{0,3})))(\/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))?$'
+        - pattern: '^((([^:]+:){7}([^:]+))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?))(\/.+)?$'
+      example: "2001:db8:85a3:8d3:1319:8a2e:370:7344"
+      description: |
+        IPv6 address, following IETF 5952 format, may be specified in form <address/mask> as:
+          - address - The /128 subnet is optional for single addresses:
+            - 2001:db8:85a3:8d3:1319:8a2e:370:7344
+            - 2001:db8:85a3:8d3:1319:8a2e:370:7344/128
+          - address/mask - an IP v6 number with a mask:
+            - 2001:db8:85a3:8d3::0/64
+            - 2001:db8:85a3:8d3::/64
+   
+    InstanceIdentifier:
+      type: string
+      pattern:  ^[A-Za-z0-9][A-Za-z0-9_]{6,62}[A-Za-z0-9]$      
+      description: Unique identifier generated by the partner OP to identify an instance of the application on a specific zone.
+    
+    
 
  ######################################################
  #  RESPONSES
@@ -497,13 +553,13 @@ components:
           example:
             status: ERROR
             message: Backend connection timeout
-    OkDeleted:
-      description: The resource has been successfully deleted
+    OkDeletionInProgress:
+      description: The resource delation request has been accepted
       content:
         application/json:
           example:
             status: OK
-            message: Deleted
+            message: Accepted
     Generic400:
       description: Invalid input
       content:


### PR DESCRIPTION
This release includes User Mobility. 

With respect to v0.9.1
- User Mobility use case is included into the documentation

With respect to v0.8.1:
-POST and trafficInfluenceID: it has been better documented how to use it -State: the different states have been described
-TIResource_Id and trafficInfluenceID: currently just trafficInfluenceID is used in the YAML -FlowInfo/flowDescriptions: it is not used number anymore to identify the protocol but a text (e.g. TCP or UDP). -the TI API now supports existing PDU sessions
-instanceid added
-flowdescription updated (just the "port" is used) -adopted CAMEL type
-ueid name modified into "Device" and modified to support TI over existing PDU sessions -avoiding or explaining Tecnical teminology ad adopting CAMARA Glossary. e.g. Device instead of UE or API Consumer instead of Application Function -FlowInfo deleted
-OpenAPI version updated to 3.0.3
-general improvement in documentation
-To let the Developer to just work on parameters actually editable, the PUT method is changed into a PATCH method with a limitation on the parameters usable and modifiable. A new resource is created, PatchTrafficInfluence that contains only the editable parameters. The same approach is also adopted for the PUT method and a new resource PostTrafficInfluence was created with just the editable parameters. -DELETE response code modified as 202. The Deletion request is accepted (not yet completed) -added response code 400 (bad request) to POST