### PR TITLE
Simple edge discovery: Optional parameters addition

### DIFF
--- a/code/API_definitions/Discovery/simple_edge_discovery.yaml
+++ b/code/API_definitions/Discovery/simple_edge_discovery.yaml
@@ -130,7 +130,12 @@ paths:
             enum: [
               "closest"
               ]
-            
+        - name: appId
+          in: query
+          required: false
+          description: Application ID of the user request
+          schema:
+            $ref: '#/components/schemas/AppId'
         - name: IP-Address
           in: header
           required: false
@@ -170,7 +175,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MecPlatforms'
+                type: object
+                properties:  
+                  mecPlatform:
+                      $ref: '#/components/schemas/MecPlatform'
+                  uri:
+                      $ref: '#/components/schemas/Uri'
+                        
         "400":
           $ref: '#/components/responses/400BadRequest'
         "401":
@@ -208,6 +219,11 @@ components:
           tokenUrl: "{tokenUrl}"
           scopes: {}
   schemas:
+    AppId:
+      type: string
+      format: uuid
+      description: A globally unique identifier associated with the artifact. Originating OP generates this identifier when artifact is submitted over NBI. If this parameter is provided, Uri of the application instance running in the selected edge is returned.
+      
     MecPlatforms:
       type: array
       items:
@@ -247,6 +263,10 @@ components:
         message: 
           type: string
           description: This parameter appears when there was an error. Human readable explanation specific to this occurrence of the problem
+    Uri:
+      type: string
+      description: URI of Service Endpoint if available where the application instance is deployed. Uri is only returned if the appId is provided
+      format: uri
       
 
 ###################################

--- a/code/API_definitions/Discovery/simple_edge_discovery.yaml
+++ b/code/API_definitions/Discovery/simple_edge_discovery.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Simple Edge Discovery API
-  version: 0.9.3
+  version: 0.9.4
   description: |
     # Find the closest MEC platform
     ---


### PR DESCRIPTION
Optional parameters addition.

In the previous contribution, the final user would not know the actual connection details . This proposal enhances the user to connect the application if they know the appId of the instance they want to use. This way: If provided an `appId` an `Uri` of the service endpoint/application instance will be returned within the edge details