### PR TITLE
Update CODEOWNERS substitute Telefonica representative

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
-* @gunjald @kevsy @crissancas @FabrizioMoggio @sergiofranciscoortiz @nicolacdnll @gainsley
+* @gunjald @kevsy @crissancas @FabrizioMoggio @nicolacdnll @gainsley @javierlozallu


### PR DESCRIPTION
Request to modify current telefonica technical representative in codeowners from Sergio Francisco Ortiz to Javier Loza who is currently contributing with LCM API