### PR TITLE
Update .spectral.yml

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,6 +1,9 @@
 # CAMARA Project - linting ruleset - documentation avaialable here:
 # https://github.com/camaraproject/Commonalities/blob/main/documentation/Linting-rules.md
-# 31.01.2024 - initial version
+# Changelog:
+# - 31.01.2024: Initial version
+# - 19.03.2024: Corrected camara-http-methods rule
+
 
 extends: "spectral:oas"
 functions:
@@ -108,7 +111,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "^(get|put|post|delete|patch|options)$"
+        match: "^(get|put|post|delete|patch|options|parameters)$"
     recommended: true  # Set to true/false to enable/disable this rule
 
   camara-get-no-request-body:


### PR DESCRIPTION
Added 19.03.2024: Corrected camara-http-methods rule 
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature



#### What this PR does / why we need it:


Update the new version of spectral tool

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #191 
Linting rules (spectral) have been updated to be compatible with TI API methods definition.

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```


