### PR TITLE
TI API Rel 0.9.4: CR in LF format

### DIFF
--- a/code/API_definitions/Traffic_Influence.yaml
+++ b/code/API_definitions/Traffic_Influence.yaml
@@ -5,7 +5,7 @@ openapi: 3.0.3
 ############################################################################
 info:
   title: OPAG-CAMARA Traffic Influence API
-  version: 0.9.3
+  version: 0.9.4
   description: |
     ## Overview
     The reference scenario foresees a Service, composed by one or more Service


### PR DESCRIPTION
Carriage Return in LF format.

#### What type of PR is this?

Add one of the following kinds:
* bug

#### What this PR does / why we need it:
CR should be in LF format while in Rel 0.9.3 it was in Windows format. I decided not to include this update in rel 0.9.3 otherwise every code line is effected and the modification were not visible anymore.


