### PR TITLE
EAM API: Add missing AppProvider

### DIFF
--- a/code/API_definitions/Edge-Application-Management.yaml
+++ b/code/API_definitions/Edge-Application-Management.yaml
@@ -859,6 +859,7 @@ components:
       required:
         - name
         - version
+        - appProvider
         - packageType
         - appRepo
         - requiredResources

--- a/code/API_definitions/Edge-Application-Management.yaml
+++ b/code/API_definitions/Edge-Application-Management.yaml
@@ -705,6 +705,8 @@ components:
           type: string
           pattern: ^[A-Za-z][A-Za-z0-9_]{1,63}$
           description: Name of the application.
+        appProvider:
+          $ref: '#/components/schemas/AppProvider'
         version:
           type: integer
           description: Application version information
@@ -861,6 +863,11 @@ components:
         - appRepo
         - requiredResources
         - componentSpec
+
+    AppProvider:
+      type: string
+      pattern: ^[A-Za-z][A-Za-z0-9_]{7,63}$
+      description: Human readable name of the Application Provider.
 
     EdgeCloudProvider:
       type: string


### PR DESCRIPTION
#### What type of PR is this?
* correction

#### What this PR does / why we need it:
Adds the missing AppProvider to the AppManifest model.

#### Which issue(s) this PR fixes:
Fixes #251 

#### Special notes for reviewers:

#### Changelog input

```
Add AppProvider field to AppManifest
```

#### Additional documentation 
