### PR TITLE
EAM API: add list apps api

### DIFF
--- a/code/API_definitions/Edge-Application-Management.yaml
+++ b/code/API_definitions/Edge-Application-Management.yaml
@@ -233,8 +233,8 @@ paths:
         - Application
       summary: Retrieve a list of existing Applications
       description: |
-        Get the list of existing Application definitions from the Edge Cloud
-        Provider.
+        Get the list of all existing Application definitions from the
+        Edge Cloud Provider that the user has permission to view.
       operationId: getApps
       parameters:
         - $ref: '#/components/parameters/x-correlator'

--- a/code/API_definitions/Edge-Application-Management.yaml
+++ b/code/API_definitions/Edge-Application-Management.yaml
@@ -225,6 +225,41 @@ paths:
           $ref: '#/components/responses/501'
         '503':
           $ref: '#/components/responses/503'
+    get:
+      security:
+        - openId:
+            - edge-application-management:apps:read
+      tags:
+        - Application
+      summary: Retrieve a list of existing Applications
+      description: |
+        Get the list of existing Application definitions from the Edge Cloud
+        Provider.
+      operationId: getApps
+      parameters:
+        - $ref: '#/components/parameters/x-correlator'
+      responses:
+        '200':
+          description: List of existing applications
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AppManifest'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+        '503':
+          $ref: '#/components/responses/503'
 
   /apps/{appId}:
     get:
@@ -701,6 +736,8 @@ components:
         Application information and requirements provided by the
         Application Provider
       properties:
+        appId:
+          $ref: '#/components/schemas/AppId'
         name:
           type: string
           pattern: ^[A-Za-z][A-Za-z0-9_]{1,63}$


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

This adds an API call to list created applications. Currently there is no way to query the existing applications outside of knowing the AppIds of created apps, which requires the client side to maintain a database of AppIds. This is not feasible for web or CLI based clients.

#### Which issue(s) this PR fixes:

Fixes #

#### Changelog input

```
 release-note

```

#### Additional documentation 

```
docs

```