### PR TITLE
EAM API: remove appid from appinstance path

### DIFF
--- a/code/API_definitions/Edge-Application-Management.yaml
+++ b/code/API_definitions/Edge-Application-Management.yaml
@@ -326,7 +326,7 @@ paths:
         '503':
           $ref: '#/components/responses/503'
 
-  /apps/{appId}/instances:
+  /appinstances:
     post:
       security:
         - openId:
@@ -341,21 +341,19 @@ paths:
       operationId: createAppInstance
       parameters:
         - $ref: '#/components/parameters/x-correlator'
-        - name: appId
-          description: |
-            A globally unique identifier associated with the
-            application. Edge Cloud Provider generates this identifier when
-            the application is submitted.
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/AppId'
       requestBody:
-        description: Array of Edge Cloud Zone
+        description: |
+          The Application ID and the array of Edge Cloud Zones to deploy
+          it to.
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AppZones'
+              type: object
+              properties:
+                appId:
+                  $ref: '#/components/schemas/AppId'
+                appZones:
+                  $ref: '#/components/schemas/AppZones'
         required: true
       responses:
         '202':
@@ -420,8 +418,8 @@ paths:
             the application.
             Edge Cloud Provider generates this identifier when the
             application is submitted.
-          in: path
-          required: true
+          in: query
+          required: false
           schema:
             $ref: '#/components/schemas/AppId'
         - name: appInstanceId
@@ -467,7 +465,7 @@ paths:
           $ref: '#/components/responses/500'
         '503':
           $ref: '#/components/responses/503'
-  /apps/{appId}/instances/{appInstanceId}:
+  /appinstances/{appInstanceId}:
     delete:
       security:
         - openId:
@@ -481,15 +479,6 @@ paths:
       operationId: deleteAppInstance
       parameters:
         - $ref: '#/components/parameters/x-correlator'
-        - name: appId
-          description: |
-            A globally unique identifier associated with the
-            application. Edge Cloud Provider generates this identifier
-            when the application is submitted.
-          in: path
-          required: true
-          schema:
-            $ref: '#/components/schemas/AppId'
         - name: appInstanceId
           in: path
           description: |

--- a/code/API_definitions/Edge-Application-Management.yaml
+++ b/code/API_definitions/Edge-Application-Management.yaml
@@ -349,6 +349,9 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - appId
+                - appZones
               properties:
                 appId:
                   $ref: '#/components/schemas/AppId'


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Removes appId from the appinstances path. For retrieval, it becomes an optional parameter, allowing a single API call to get appinstances from different Apps. For delete, it is not necessary because appInstanceId is sufficient to identify the instance.

#### Which issue(s) this PR fixes:

Fixes #299 

#### Special notes for reviewers:

#### Changelog input

```
 release-note

```

#### Additional documentation 

```
docs

```
