### PR TITLE
EAM API: change AppManifest version to string

### DIFF
--- a/code/API_definitions/Edge-Application-Management.yaml
+++ b/code/API_definitions/Edge-Application-Management.yaml
@@ -706,7 +706,7 @@ components:
           pattern: ^[A-Za-z][A-Za-z0-9_]{1,63}$
           description: Name of the application.
         version:
-          type: integer
+          type: string
           description: Application version information
         packageType:
           description: Format of the application image package


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Change AppManifest version from int to string, to allow version to be in [semver](https://semver.org/) format, i.e. "1.0.1", or like a docker tag, i.e. "latest" or "stable-1.0", or an integer as it was originally. Basically requiring it to an integer is too limiting.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
change AppManifest version field type from integer to string
```

#### Additional documentation 

```
docs

```
