### PR TITLE
EAM API: clarify appinstances get behavior

### DIFF
--- a/code/API_definitions/Edge-Application-Management.yaml
+++ b/code/API_definitions/Edge-Application-Management.yaml
@@ -479,7 +479,10 @@ paths:
             $ref: '#/components/schemas/EdgeCloudRegion'
       responses:
         '200':
-          description: Information of Application Instances
+          description: |
+            List of application instances. Returns an empty list if no
+            instances were found or none match the specified query
+            parameters.
           headers:
             x-correlator:
               $ref: "#/components/headers/x-correlator"


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Clarifies the behavior of the GET appinstances API if there are no matching instances to return. Implementors may consider returning 404 in this case, but I believe it is more correct to return 200 with an empty list, because:
- 404 is also returned if the URL path is incorrect, which makes it hard to distinguish between no matches vs invalid URL path
- Users (in particular tests) may intentionally be checking for the absence of an instance. Returning 404 in this case complicates verifying the absence of an instance.

#### Which issue(s) this PR fixes:

#### Special notes for reviewers:

#### Changelog input

#### Additional documentation 
