### PR TITLE
EAM API: make GET appinstances response data consistent

### DIFF
--- a/code/API_definitions/Edge-Application-Management.yaml
+++ b/code/API_definitions/Edge-Application-Management.yaml
@@ -486,13 +486,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  appInstanceInfo:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/AppInstanceInfo'
-                minItems: 1
+                type: array
+                items:
+                  $ref: '#/components/schemas/AppInstanceInfo'
         '401':
           $ref: '#/components/responses/401'
         '403':


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

This removes an unnecessary layer of hierarchy in the GET appinstances response, so it returns an array of objects rather than an array of objects encased in a parent object. This also makes it consistent with GET apps and GET edge-cloud-zones which also return arrays of objects, not arrays of objects inside an object.

#### Which issue(s) this PR fixes:

#### Special notes for reviewers:

#### Changelog input

```
 release-note
- remove enclosing object in GET appinstances response
```

#### Additional documentation 
